### PR TITLE
Add documentation for how to build the documents using Sphinx

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -37,7 +37,7 @@ $(JSDOC): package-lock.json
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
 show:
-	@python -c "import webbrowser; webbrowser.open_new_tab('file://$(PWD)/build/html/index.html')"
+	@python -c "import webbrowser; webbrowser.open_new_tab('file://$(PWD)/_build/html/index.html')"
 
 push: html
 	ghp-import -pn build/html/

--- a/docs/contribute.md
+++ b/docs/contribute.md
@@ -59,6 +59,29 @@ As you change the code in `src/`,
 the javascript will automatically be re-built,
 but you'll be required to refresh the page.
 
+## Build documentation locally
+
+thebe documentation are located under the `/docs` directory. They are build using [Sphinx](https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html). To install the required Python packages, run:
+
+```bash
+cd docs/
+pip install -r doc-requirements.txt
+```
+
+> You will also need to install [Node.js](https://nodejs.org/) and [NPM](https://www.npmjs.com/) on your system if you havn't already.
+
+After you have the Python packages and NPM installed, run the following to build the documents:
+
+```bash
+make html
+```
+
+Last, run the following to view the build documentation locally:
+
+```bash
+make show
+```
+
 # Committing changes
 
 Thebe uses code autoformatting so you don't need to worry about style lint,


### PR DESCRIPTION
## What does this PR contain

* Add document on how to build the docs using Sphinx so that people who want to contribute to docs can build locally
* Fix file path in `docs/Makefile` so that `make show` works