### PR TITLE
use localStorage to persist binder pods across pages

### DIFF
--- a/src/thebelab.js
+++ b/src/thebelab.js
@@ -419,6 +419,7 @@ export function requestBinder({
           "Saved binder pod info seems to be invalid, respawning pod",
           err
         );
+        window.localStorage.removeItem("thebe-binder-" + url);
       }
     }
 

--- a/src/thebelab.js
+++ b/src/thebelab.js
@@ -396,7 +396,9 @@ export function requestBinder({
 
   return new Promise(async (resolve, reject) => {
     // if binder already spawned our pod and we remember the creds, reuse it
-    let existing_server = JSON.parse(window.localStorage.getItem("thebe-binder-" + url));
+    let existing_server = JSON.parse(
+      window.localStorage.getItem("thebe-binder-" + url)
+    );
     if (
       existing_server !== null &&
       new Date().getTime() - new Date(existing_server.started).getTime() < 86400


### PR DESCRIPTION
This should resolve #224 (we can make a new issue for the persisting kernel (not binder pod) part if needed).

When Binder spawns a pod, the jupyter pod URL and token are saved in the browser's localStorage. When Thebe is activated and there is already a pod URL+token in localStorage, it will try to reuse the existing pod. If it fails, then it falls back to creating a new pod.