### PR TITLE
📚 DOCS: Go through docs/strings & change ThebeLab -> Thebe

### DIFF
--- a/docs/config_reference.rst
+++ b/docs/config_reference.rst
@@ -3,7 +3,7 @@ Configuration Reference
 =======================
 
 Here is an example of all possible configuration
-options for ThebeLab. This is what you place in between the
+options for Thebe. This is what you place in between the
 ``<script type="text/x-thebe-config">`` HTML tags on your page.
 
 .. include:: ../README.md

--- a/docs/configure.rst
+++ b/docs/configure.rst
@@ -1,21 +1,21 @@
-==================
-Configure Thebelab
-==================
+===============
+Configure Thebe
+===============
 
-You control Thebelab's behavior with a configuration block that is placed somewhere
+You control Thebe's behavior with a configuration block that is placed somewhere
 in a page's HTML. The block has the following structure:
 
 .. code-block:: html
 
    <script type="text/x-thebe-config">
-      { 
+      {
           a: collection
           of: key
           val: pairs
       }
    </script>
 
-For example, the following configuration tells Thebelab to use a BinderHub for its
+For example, the following configuration tells Thebe to use a BinderHub for its
 sessions, as well as the repository to use with Binder:
 
 .. code-block:: html
@@ -30,17 +30,17 @@ sessions, as well as the repository to use with Binder:
     }
     </script>
 
-When Thebelab is launched on a page, this configuration is used to control
+When Thebe is launched on a page, this configuration is used to control
 its behavior.
 
-See the sections below for things that you can control with Thebelab configuration.
+See the sections below for things that you can control with Thebe configuration.
 
 
 Configure the kernel that will be launched
 ==========================================
 
-To configure the kernel that Thebelab requests when it launches, use the
-following section in the Thebelab configuration:
+To configure the kernel that Thebe requests when it launches, use the
+following section in the Thebe configuration:
 
 .. code-block:: javascript
 
@@ -48,13 +48,13 @@ following section in the Thebelab configuration:
      kernelName: "python3",
    },
 
-When Thebelab is launched, it will request a kernel of this name for the page.
+When Thebe is launched, it will request a kernel of this name for the page.
 Note that currently there can be only one kernel per page.
 
 .. note::
 
    You must ensure that the value of ``kernelName`` exists in the environment that
-   Thebelab tries to launch. Some short-hands for certain languages (like ``python``)
+   Thebe tries to launch. Some short-hands for certain languages (like ``python``)
    may also work.
 
 
@@ -80,7 +80,7 @@ Customize CodeMirror
 
 CodeMirror is the tool used to convert your code cells into editable cells.
 It has a number of configuration options, such as theming and syntax highlighting.
-You can edit all of these attributes in a cell with the following thebelab configuration:
+You can edit all of these attributes in a cell with the following thebe configuration:
 
 .. code:: html
 

--- a/docs/events.rst
+++ b/docs/events.rst
@@ -1,11 +1,11 @@
-Event hooks in Thebelab
-=======================
+Event hooks in Thebe
+====================
 
-When Thebelab is launched (with ``thebelab.bootstrap``), it will emit a series
+When Thebe is launched (with ``thebelab.bootstrap``), it will emit a series
 of events corresponding to the state of the launch process. You can plug into
 these events to control the behavior on your page.
 
-To do so, use the ``status`` event within Thebelab, like so:
+To do so, use the ``status`` event within Thebe, like so:
 
 .. code-block:: javascript
 
@@ -14,7 +14,7 @@ To do so, use the ``status`` event within Thebelab, like so:
     });
 
 In the above code, the ``data`` object contains a collection of information about
-Thebelab, and ``data.status`` will reflect the current state of Thebelab. This will
+Thebe, and ``data.status`` will reflect the current state of Thebe. This will
 cycle between these states:
 
 * ``building``
@@ -23,5 +23,5 @@ cycle between these states:
 * ``ready``
 
 These events can be used to do things like running code once the Jupyter Kernels is
-ready, or manipulating the page DOM before launching Thebelab to result in certain
+ready, or manipulating the page DOM before launching Thebe to result in certain
 behavior (e.g. a "loading status" button).

--- a/docs/howto/initialize_cells.rst
+++ b/docs/howto/initialize_cells.rst
@@ -1,22 +1,22 @@
-==================================
-Running cells when Thebelab starts
-==================================
+===============================
+Running cells when Thebe starts
+===============================
 
-Sometimes it is helpful to automatically run some cells when Thebelab starts.
+Sometimes it is helpful to automatically run some cells when Thebe starts.
 For example, if you'd like to pre-define some variables or import a function
 that you'll use later on. This lets you focus the code that users read on the
 ideas that you want to convey.
 
-Thebelab can be controlled via Javascript after it has been initialized. Below
+Thebe can be controlled via Javascript after it has been initialized. Below
 are two ways that you can configure your Javascript to run code under-the-hood.
 
-Running cells when Thebelab is initialized
-==========================================
+Running cells when Thebe is initialized
+=======================================
 
 A straightforward way to run code is to simply *simulate a click* on the buttons that
-are created when you launch Thebelab. By selecting the Thebelab button and calling
+are created when you launch Thebe. By selecting the Thebe button and calling
 the ``click()`` method, the code in that cell will be run (and outputs will show)
-once the Thebelab kernel is ready.
+once the Thebe kernel is ready.
 
 Here's a code sample that selects all cells with a tag called ``thebelab-init`` and
 simulates a click on the button.
@@ -24,19 +24,19 @@ simulates a click on the button.
 .. code-block:: javascript
 
    thebelab.events.on("request-kernel")(() => {
-       // Find any cells with an initialization tag and ask ThebeLab to run them when ready
+       // Find any cells with an initialization tag and ask Thebe to run them when ready
        var thebeInitCells = document.querySelectorAll('.thebelab-init');
        thebeInitCells.forEach((cell) => {
-           console.log("Initializing ThebeLab with cell: " + cell.id);
+           console.log("Initializing Thebe with cell: " + cell.id);
            const initButton = cell.querySelector('.thebelab-run-button');
            initButton.click();
        });
    }
 
-Running custom code with Thebelab
-=================================
+Running custom code with Thebe
+==============================
 
-In addition, you can run your own custom code from the Thebelab object with
+In addition, you can run your own custom code from the Thebe object with
 Javascript using the ``requestExecute`` method. Below is a code snippet that
 uses the same event trigger, but in this case runs some custom code against the kernel
 once it is ready.
@@ -44,7 +44,7 @@ once it is ready.
 .. code-block:: javascript
 
    thebelab.events.on("request-kernel")((kernel) => {
-       // Find any cells with an initialization tag and ask ThebeLab to run them when ready
+       // Find any cells with an initialization tag and ask Thebe to run them when ready
        kernel.requestExecute({code: "import numpy"})
    }
 

--- a/docs/minimal_example.rst
+++ b/docs/minimal_example.rst
@@ -7,15 +7,15 @@ A minimal example
 This page illustrates a minimal setup to get Thebe Lab running, using
 `mybinder <http://mybinder.org/>`_ as a
 kernel (i.e. computation backend) provider. This guide will go step-by-step
-in loading ThebeLab and activating it so that your code cells become active.
+in loading Thebe and activating it so that your code cells become active.
 
-Loading and configuring ThebeLab
-================================
+Loading and configuring Thebe
+=============================
 
-In order to use ThebeLab, we must first set its configuration. This must be
-done **before** ThebeLab is loaded from a CDN or a local script.
+In order to use Thebe, we must first set its configuration. This must be
+done **before** Thebe is loaded from a CDN or a local script.
 
-Here's a sample configuration for ThebeLab
+Here's a sample configuration for Thebe
 
 .. raw:: html
 
@@ -41,11 +41,11 @@ Here's a sample configuration for ThebeLab
      }
    </script>
 
-In this case, ``requestKernel: true`` asks Thebelab to request a kernel
+In this case, ``requestKernel: true`` asks Thebe to request a kernel
 immediately upon being loaded, and ``binderOptions`` provides the repository
 that Binder will use to give us a Kernel.
 
-Next, we'll load Thebelab from a CDN:
+Next, we'll load Thebe from a CDN:
 
 .. raw:: html
 
@@ -55,11 +55,11 @@ Next, we'll load Thebelab from a CDN:
 
    <script src="https://unpkg.com/thebelab@latest/lib/index.js"></script>
 
-Adding a button to activate ThebeLab
-====================================
+Adding a button to activate Thebe
+=================================
 
-There are many ways you can activate Thebelab. In this case, we'll add a
-button to our page, and configure it to **bootstrap** Thebelab once it is
+There are many ways you can activate Thebe. In this case, we'll add a
+button to our page, and configure it to **bootstrap** Thebe once it is
 clicked. We'll do this with a little bit of Javascript.
 
 .. raw:: html
@@ -73,7 +73,7 @@ clicked. We'll do this with a little bit of Javascript.
    document.querySelector("#activateButton").addEventListener('click', bootstrapThebe)
    </script>
 
-Placing the button and adding the JavaScript to enable Thebelab was done with the
+Placing the button and adding the JavaScript to enable Thebe was done with the
 code below:
 
 .. code:: html
@@ -91,7 +91,7 @@ code below:
 Adding code cells
 =================
 
-Finally, we'll add code cells that ThebeLab can activate. By default, ThebeLab
+Finally, we'll add code cells that Thebe can activate. By default, Thebe
 will look for any HTML elements with ``data-executable="true"``. We'll also add
 a ``data-language="python"`` attribute to enable syntax highlighting with CodeMirror.
 
@@ -106,16 +106,16 @@ Here's the code that created the cell above:
 
    <pre data-executable="true" data-language="python">print("Hello!")</pre>
 
-Press the ThebeLab button above to activate this cell, then press the "Run" button,
+Press the Thebe button above to activate this cell, then press the "Run" button,
 or "Shift-Enter" to execute this cell.
 
 .. note::
 
-   When ThebeLab is activated in this example, it must first ask Binder for a kernel.
+   When Thebe is activated in this example, it must first ask Binder for a kernel.
    This may take several seconds.
 
 Now let's try another cell that generates a Matplotlib plot. Because we've
-configured ThebeLab to use Binder with an environment that has Numpy and
+configured Thebe to use Binder with an environment that has Numpy and
 Matplotlib, this works as expected. Try modifying the cell contents and
 re-running!
 

--- a/docs/minimal_example.rst
+++ b/docs/minimal_example.rst
@@ -4,7 +4,7 @@
 A minimal example
 =================
 
-This page illustrates a minimal setup to get Thebe Lab running, using
+This page illustrates a minimal setup to get Thebe running, using
 `mybinder <http://mybinder.org/>`_ as a
 kernel (i.e. computation backend) provider. This guide will go step-by-step
 in loading Thebe and activating it so that your code cells become active.

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "thebe-docs",
   "version": "0.0.0",
-  "description": "thebelab docs js dependencies",
+  "description": "thebe docs js dependencies",
   "main": "''",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/docs/start.rst
+++ b/docs/start.rst
@@ -2,12 +2,12 @@
 Get started
 ===========
 
-In order to use Thebelab, you must take the following steps on a page:
+In order to use Thebe, you must take the following steps on a page:
 
-Load the thebelab javascript bundle
-===================================
+Load the thebe javascript bundle
+================================
 
-The Thebelab Javascript is most-easily obtained from a CDN.
+The Thebe Javascript is most-easily obtained from a CDN.
 You can load the javascript library from a CDN by including this on a page:
 
 .. code:: html
@@ -16,11 +16,11 @@ You can load the javascript library from a CDN by including this on a page:
 
 Alternatively, you can download the bundle and include it along with your site.
 
-Configure Thebelab in your page's HTML
-======================================
+Configure Thebe in your page's HTML
+===================================
 
-Thebelab looks for a specific HTML block for its configuration. This happens
-when Thebelab is "bootstrapped" (i.e., launched).
+Thebe looks for a specific HTML block for its configuration. This happens
+when Thebe is "bootstrapped" (i.e., launched).
 
 The configuration block has the following structure:
 
@@ -34,14 +34,14 @@ The configuration block has the following structure:
       }
    </script>
 
-See :doc:`configure` for information about how and what to configure with Thebelab.
+See :doc:`configure` for information about how and what to configure with Thebe.
 
 
-Bootstrap Thebelab on the page
-==============================
+Bootstrap Thebe on the page
+===========================
 
-If the Thebelab Javascript bundle is loaded, and the configuration file is present,
-you may bootstrap (i.e., launch) Thebelab by calling the following Javascript function:
+If the Thebe Javascript bundle is loaded, and the configuration file is present,
+you may bootstrap (i.e., launch) Thebe by calling the following Javascript function:
 
 ``thebelab.bootstrap()``
 
@@ -56,5 +56,5 @@ Calling the bootstrap function is generally accomplished by connecting it to the
 
 .. tip::
 
-   If ``bootstrap: true`` is in the Thebelab configuration, this will be triggered
+   If ``bootstrap: true`` is in the Thebe configuration, this will be triggered
    automatically upon page load.

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,4 +1,4 @@
-# Examples of use of ThebeLab
+# Examples of use of Thebe
 
 You can [browse them online](https://minrk.github.io/thebelab/).
 To serve them locally instead, run:
@@ -9,4 +9,4 @@ and navigate to http://127.0.0.1:8000.
 
 Some of the examples use a small extension `thebe_status_field`
 provided here; this extension may eventually be moved into the main
-`ThebeLab` library if there is popular request.
+`Thebe` library if there is popular request.

--- a/examples/demo.html
+++ b/examples/demo.html
@@ -1,9 +1,9 @@
 <html>
   <head>
-    <title>ThebeLab demo</title>
+    <title>Thebe demo</title>
   </head>
   <body>
-    <h1>ThebeLab demo</h1>
+    <h1>Thebe demo</h1>
 
     <ul>
       <li><a href="demo-static.html">A static web page</li>
@@ -14,8 +14,8 @@
     <h2>References</h2>
 
     <ul>
-      <li><a href="https://minrk.github.io/thebelab/">ThebeLab documentation and examples</a></li>
-      <li><a href="https://github.com/minrk/thebelab">GitHub repository</a></li>
+      <li><a href="https://thebe.readthedocs.io/">Thebe documentation and examples</a></li>
+      <li><a href="https://github.com/executablebooks/thebe">GitHub repository</a></li>
     </ul>
   </body>
 </html>

--- a/examples/index.html
+++ b/examples/index.html
@@ -74,7 +74,7 @@ plt.plot(x, np.cos(x))</pre>
   <li><a href="prompts.html">Alternative computational environments; code cells with prompts and outputs</a>;
   <li><a href="local.html">Using a local Jupyter server as kernel provider</a>;
   <li><a href="demo-preview.html">Setting predefined output for cells</a>;
-  <li><a href="http://sage-package.readthedocs.io/en/latest/sage_package/sphinx-demo.html">ThebeLab in use for SageMath documentation</a>
+  <li><a href="http://sage-package.readthedocs.io/en/latest/sage_package/sphinx-demo.html">Thebe in use for SageMath documentation</a>
         <a href="http://sage-package.readthedocs.io/en/latest/sage_package/thebe.html">(about)</a>;
         Showcases a fancy activate button, and fetching thebe and running computations locally when possible.
         Relevant files:
@@ -83,7 +83,7 @@ plt.plot(x, np.cos(x))</pre>
             <li><a href="https://github.com/sagemath/sage-package/tree/master/sage_package/themes/sage/static/thebe_status_field.js">thebe_status_field.js</a></li>
         </ul>
   </li>
-  <li><a href="https://sebasguts.github.io/thebelab_test_gap/chap42">ThebeLab in use for GAP documentation</a>.</li>
+  <li><a href="https://sebasguts.github.io/thebelab_test_gap/chap42">Thebe in use for GAP documentation</a>.</li>
   </ul>
 
 </body>

--- a/examples/index.html
+++ b/examples/index.html
@@ -1,7 +1,7 @@
 <html>
 <head>
   <meta HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=UTF-8">
-  <title>Thebe Lab examples</title>
+  <title>Thebe examples</title>
   <link rel="stylesheet" type="text/css" href="index.css" />
 
   <!-- Configure and load Thebe !-->
@@ -22,10 +22,10 @@
 
 </head>
 <body>
-  <h1>Thebe Lab</h1>
+  <h1>Thebe</h1>
 
   <p>
-    <a href="https://github.com/minrk/thebelab">Thebe Lab</a>
+    <a href="https://github.com/minrk/thebelab">Thebe</a>
     is an experiment attempting to rebuild
     <a href="https://github.com/oreillymedia/thebe">Thebe</a>
     with javascript APIs provided by
@@ -38,7 +38,7 @@
 
   <h2>A minimal example</h2>
 
-  This page illustrates a minimal setup to get Thebe Lab running, using
+  This page illustrates a minimal setup to get Thebe running, using
   <a href="http://mybinder.org">mybinder</a> as <em>kernel</em> (i.e.
   computation backend) provider. See the
   <a href="https://github.com/minrk/thebelab/blob/master/examples/index.html">

--- a/examples/local.html
+++ b/examples/local.html
@@ -1,7 +1,7 @@
 <html>
 <head>
   <meta HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=UTF-8">
-  <title>Thebe Lab examples</title>
+  <title>Thebe examples</title>
   <link rel="stylesheet" type="text/css" href="index.css" />
 
   <!-- Configure and load Thebe !-->
@@ -23,9 +23,9 @@
 
 </head>
 <body>
-  <h1>Thebe Lab: using a local server</h1>
+  <h1>Thebe: using a local server</h1>
 
-  <p>This page illustrates how to setup Thebe Lab, using a local
+  <p>This page illustrates how to setup Thebe, using a local
   Jupyter server as kernel provider. This assumes that you have
   started the local server as:
   <pre>

--- a/examples/status_field.html
+++ b/examples/status_field.html
@@ -1,7 +1,7 @@
 <html>
 <head>
   <meta HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=UTF-8">
-  <title>Thebe Lab example: status button, styling, ...</title>
+  <title>Thebe example: status button, styling, ...</title>
   <link rel="stylesheet" type="text/css" href="index.css" />
 
   <!-- Thebe configuration !-->
@@ -35,7 +35,7 @@
   </script>
 </head>
 <body>
-  <h1>Thebe Lab example: status button, styling, ...</h1>
+  <h1>Thebe example: status button, styling, ...</h1>
 
   Status: <span class="thebe_status_field"></span>
 

--- a/examples/status_field.html
+++ b/examples/status_field.html
@@ -27,7 +27,8 @@
   <script src="thebe_status_field.js" type="text/javascript"></script>
   <link   href="thebe_status_field.css" rel="stylesheet" type="text/css"/>
 
-  <script><!-- use window.onload to defer the execution until the page is loaded !-->
+  <script>
+    // use window.onload to defer the execution until the page is loaded
     window.onload = function () {
       thebe_place_status_field();
       thebe_activate_cells();

--- a/examples/thebe_status_field.js
+++ b/examples/thebe_status_field.js
@@ -5,7 +5,7 @@ function thebe_place_activate_button() {
     '<input type="button"\
                   onclick="thebe_activate_button_function()"\
                   value="Activate"\
-                  title="ThebeLab (requires internet):\nClick to activate code cells in this page.\nYou can then edit and run them.\nComputations courtesy of mybinder.org."\
+                  title="Thebe (requires internet):\nClick to activate code cells in this page.\nYou can then edit and run them.\nComputations courtesy of mybinder.org."\
                    class="thebe-status-field"/>'
   );
 }
@@ -17,7 +17,7 @@ function thebe_remove_activate_button() {
 function thebe_place_status_field() {
   $(".thebe_status_field").html(
     '<span class="thebe-status-field"\
-                title="ThebeLab status.\nClick `run` to execute code cells.\nComputations courtesy of mybinder.org.">\
+                title="Thebe status.\nClick `run` to execute code cells.\nComputations courtesy of mybinder.org.">\
           </span>'
   );
 }
@@ -43,6 +43,6 @@ function thebe_activate_button_function() {
       thebe_activate_cells();
     })
     .fail(function (jqxhr, settings, exception) {
-      $("div.log").text("Could not fetch ThebeLab library.");
+      $("div.log").text("Could not fetch Thebe library.");
     });
 }

--- a/examples/widgets.html
+++ b/examples/widgets.html
@@ -1,7 +1,7 @@
 <html>
 <head>
   <meta HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=UTF-8">
-  <title>Thebe Lab examples</title>
+  <title>Thebe examples</title>
   <link rel="stylesheet" type="text/css" href="index.css" />
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.4/require.min.js">
@@ -27,10 +27,10 @@
 
 </head>
 <body>
-  <h1>Thebe Lab and Jupyter interactive widgets</h1>
+  <h1>Thebe and Jupyter interactive widgets</h1>
 
   <p>This page illustrates a minimal setup to get custom Jupyter interactive
-  widgets in Thebe Lab.</p>
+  widgets in Thebe.</p>
 
   <p>This requires adding a script tag to load requirejs on
   page, for thebelab to be able to load the JavaScript assets for custom


### PR DESCRIPTION
This should be a non-invasive change to refresh some of the documentation when referring to Thebe.

I have updated some code, but only comments and strings that have no other effects.