### PR TITLE
📚 DOCS: Update repository urls to point to executable books

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,6 +1,6 @@
 # Examples of use of Thebe
 
-You can [browse them online](https://minrk.github.io/thebelab/).
+You can [browse them online](https://executablebooks.github.io/thebe/).
 To serve them locally instead, run:
 
     python -m http.server

--- a/examples/index.html
+++ b/examples/index.html
@@ -25,7 +25,7 @@
   <h1>Thebe</h1>
 
   <p>
-    <a href="https://github.com/minrk/thebelab">Thebe</a>
+    <a href="https://github.com/executablebooks/thebe">Thebe</a>
     is an experiment attempting to rebuild
     <a href="https://github.com/oreillymedia/thebe">Thebe</a>
     with javascript APIs provided by
@@ -41,7 +41,7 @@
   This page illustrates a minimal setup to get Thebe running, using
   <a href="http://mybinder.org">mybinder</a> as <em>kernel</em> (i.e.
   computation backend) provider. See the
-  <a href="https://github.com/minrk/thebelab/blob/master/examples/index.html">
+  <a href="https://github.com/executablebooks/thebe/blob/master/examples/index.html">
   source file</a> for details.
 
   <p>This is a cell:</p>

--- a/examples/local.html
+++ b/examples/local.html
@@ -34,7 +34,7 @@
   and that it's running on port 8888</p>
 
   See also the
-  <a href="https://github.com/minrk/thebelab/blob/master/examples/local.html">source file</a>.
+  <a href="https://github.com/executablebooks/thebe/blob/master/examples/local.html">source file</a>.
 
   <pre data-executable="true" data-language="python">print("Hello!")</pre>
   <pre data-executable="true" data-language="python">1+1</pre>

--- a/examples/prompts.html
+++ b/examples/prompts.html
@@ -40,7 +40,7 @@
   untouched</p>
 
   See also the
-  <a href="https://github.com/minrk/thebelab/blob/master/examples/prompts.html">source file</a>.
+  <a href="https://github.com/executablebooks/thebe/blob/master/examples/prompts.html">source file</a>.
 
   <p>This is the original cell:</p>
   <pre>


### PR DESCRIPTION
Another small PR, updating some links to point to the new repository.

See also: #230