### PR TITLE
show an error message when the kernel is dead

### DIFF
--- a/src/thebelab.js
+++ b/src/thebelab.js
@@ -239,7 +239,16 @@ function renderCell(element, options) {
       events.trigger("request-kernel");
     }
     kernelPromise.then((kernel) => {
-      outputArea.future = kernel.requestExecute({ code: code });
+      try {
+        outputArea.future = kernel.requestExecute({ code: code });
+      } catch (error) {
+        outputArea.model.clear();
+        outputArea.model.add({
+          output_type: "stream",
+          name: "stderr",
+          text: `Failed to execute. ${error} Please refresh the page.`,
+        });
+      }
     });
     return false;
   }


### PR DESCRIPTION
This doesn't hook the kernel up again, and only shows an error message. But hey—still better than silently dumping exceptions into the console. :)