### PR TITLE
✨ NEW: make savedSession behavior configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,10 +75,19 @@ A full config script with defaults:
   // Options for requesting a notebook server from mybinder.org
   binderOptions: {
     repo: "minrk/ligo-binder",
+
+    // only repo is required, the rest below are defaults:
     ref: "master",
     binderUrl: "https://mybinder.org",
     // select repository source (optional). Supports Github(default), Gitlab, and Git
     repoProvider: "github",
+    savedSession {
+      // if enabled, thebe will store and try to re-use
+      // connections (with credentials!) to running servers
+      enabled: true,
+      maxAge: 86400, // the max age in seconds to consider re-using a session
+      storagePrefix: "thebe-binder-",
+    }
   },
 
   // Options for requesting a kernel from the notebook server

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ A full config script with defaults:
     binderUrl: "https://mybinder.org",
     // select repository source (optional). Supports Github(default), Gitlab, and Git
     repoProvider: "github",
-    savedSession {
+    savedSession: {
       // if enabled, thebe will store and try to re-use
       // connections (with credentials!) to running servers
       enabled: true,

--- a/src/thebelab.js
+++ b/src/thebelab.js
@@ -446,10 +446,11 @@ export function requestBinder({
     }
     console.debug("Saved binder session detected");
     let existingServer = JSON.parse(storedInfoJSON);
-    let timestamp = new Date(existingServer.timestamp);
-    if (new Date().getTime() - timestamp.getTime() < savedSession.maxAge) {
+    let lastUsed = new Date(existingServer.lastUsed);
+    let ageSeconds = (new Date() - lastUsed) / 1000;
+    if (ageSeconds > savedSession.maxAge) {
       console.debug(
-        `Not using expired binder session for ${existingServer.url} from ${timestamp}`
+        `Not using expired binder session for ${existingServer.url} from ${lastUsed}`
       );
       window.localStorage.removeItem(storageKey);
       return;

--- a/src/thebelab.js
+++ b/src/thebelab.js
@@ -69,6 +69,11 @@ const _defaultOptions = {
   binderOptions: {
     ref: "master",
     binderUrl: "https://mybinder.org",
+    savedSession: {
+      enabled: true,
+      maxAge: 86400,
+      storagePrefix: "thebe-binder-",
+    },
   },
   kernelOptions: {
     path: "/",
@@ -377,6 +382,7 @@ export function requestBinder({
   ref = "master",
   binderUrl = null,
   repoProvider = "",
+  savedSession = _defaultOptions.binderOptions.savedSession,
 } = {}) {
   // request a server from Binder
   // returns a Promise that will resolve with a serverSettings dict
@@ -390,6 +396,9 @@ export function requestBinder({
   console.log("binder url", binderUrl, defaults);
   binderUrl = binderUrl || defaults.binderUrl;
   ref = ref || defaults.ref;
+  savedSession = savedSession || defaults.savedSession;
+  savedSession = $.extend(true, defaults.savedSession, savedSession);
+
   let url;
 
   if (repoProvider.toLowerCase() === "git") {
@@ -424,34 +433,69 @@ export function requestBinder({
   }
   console.log("Binder build URL", url);
 
-  return new Promise(async (resolve, reject) => {
-    // if binder already spawned our pod and we remember the creds, reuse it
-    let existing_server = JSON.parse(
-      window.localStorage.getItem("thebe-binder-" + url)
+  const storageKey = savedSession.storagePrefix + url;
+
+  async function getExistingServer() {
+    if (!savedSession.enabled) {
+      return;
+    }
+    let storedInfoJSON = window.localStorage.getItem(storageKey);
+    if (storedInfoJSON == null) {
+      console.debug("No session saved in ", storageKey);
+      return;
+    }
+    console.debug("Saved binder session detected");
+    let existingServer = JSON.parse(storedInfoJSON);
+    let timestamp = new Date(existingServer.timestamp);
+    if (new Date().getTime() - timestamp.getTime() < savedSession.maxAge) {
+      console.debug(
+        `Not using expired binder session for ${existingServer.url} from ${timestamp}`
+      );
+      window.localStorage.removeItem(storageKey);
+      return;
+    }
+    let settings = ServerConnection.makeSettings({
+      baseUrl: existingServer.url,
+      wsUrl: "ws" + existingServer.url.slice(4),
+      token: existingServer.token,
+      appendToken: true,
+    });
+    try {
+      await KernelAPI.listRunning(settings);
+    } catch (err) {
+      console.log(
+        "Saved binder connection appears to be invalid, requesting new session",
+        err
+      );
+      window.localStorage.removeItem(storageKey);
+      return;
+    }
+    // refresh lastUsed timestamp in stored info
+    existingServer.lastUsed = new Date();
+    window.localStorage.setItem(storageKey, JSON.stringify(existingServer));
+    console.log(
+      `Saved binder session is valid, reusing connection to ${existingServer.url}`
     );
-    if (
-      existing_server !== null &&
-      new Date().getTime() - new Date(existing_server.started).getTime() < 86400
-    ) {
-      console.log("Saved binder pod info detected");
-      let settings = ServerConnection.makeSettings({
-        baseUrl: existing_server.url,
-        wsUrl: "ws" + existing_server.url.slice(4),
-        token: existing_server.token,
-        appendToken: true,
-      });
-      try {
-        await KernelAPI.listRunning(settings);
-        console.log("Saved binder pod is valid, reusing connection");
-        resolve(settings);
-        return;
-      } catch (err) {
-        console.log(
-          "Saved binder pod info seems to be invalid, respawning pod",
-          err
-        );
-        window.localStorage.removeItem("thebe-binder-" + url);
-      }
+    return settings;
+  }
+
+  return new Promise(async (resolve, reject) => {
+    // if binder already spawned our server and we remember the creds
+    // try to reuse it
+    let existingServer;
+    try {
+      existingServer = await getExistingServer();
+    } catch (err) {
+      // catch unhandled errors such as JSON parse errors,
+      // invalid formats, permission error on localStorage, etc.
+      console.error("Failed to load existing server connection", err);
+    }
+
+    if (existingServer) {
+      // found an existing server
+      // return it instead of requesting a new one
+      resolve(existingServer);
+      return;
     }
 
     events.trigger("status", {
@@ -500,11 +544,11 @@ export function requestBinder({
           try {
             // save the current connection url+token to reuse later
             window.localStorage.setItem(
-              "thebe-binder-" + url,
+              storageKey,
               JSON.stringify({
                 url: msg.url,
                 token: msg.token,
-                started: new Date(),
+                lastUsed: new Date(),
               })
             );
           } catch (e) {


### PR DESCRIPTION
adds binderOptions.savedSession configuration to give users a little control over #266

- toggle behavior off entirely with `savedSession.enabled`
- set max age in seconds with `savedSession.maxAge`
- specify storage prefix with `savedSession.storagePrefix`

and reorganize the code a little bit to make the flow a little easier to manage with all the different stages to abort, including JSON parse errors, etc.