### PR TITLE
📚 DOCS: Added language about read-only codeMirror default

### DIFF
--- a/docs/configure.rst
+++ b/docs/configure.rst
@@ -82,7 +82,7 @@ CodeMirror is the tool used to convert your code cells into editable cells.
 It has a number of configuration options, such as theming and syntax highlighting.
 You can edit all of these attributes in a cell with the following thebe configuration:
 
-.. code:: html
+.. code:: javascript
 
 
    // Additional options to pass to CodeMirror instances
@@ -91,7 +91,7 @@ You can edit all of these attributes in a cell with the following thebe configur
 You can use any of `the available CodeMirror configurations <https://codemirror.net/doc/manual.html#config>`_.
 For example, the following configuration changes the `CodeMirror theme <https://codemirror.net/theme/>`_:
 
-.. code:: html
+.. code:: javascript
 
    codeMirrorConfig: {
        theme: "abcdef"
@@ -139,12 +139,27 @@ The above code should be styled according to the
 Mark a code cell as read-only
 =============================
 
-If you'd like a code cell to be runnable by Thebe, but not *editable* by the user, you
+If you would like a code cell to be runnable by Thebe, but not *editable* by the user, you
 may mark it as "read-only" with the following syntax:
 
 .. code-block:: html
 
    <pre data-executable data-readonly>print("I cannot be modified")</pre>
 
-Users will not be able to modify the code when Thebe is activated, though they can still
+Users will not be able to modify the code once Thebe is activated, though they can still
 press the "run" button to see the outputs.
+
+Alternatively, you can use the codeMirrorConfig in order to set the default as read-only for all cells:
+
+.. code:: javascript
+
+   codeMirrorConfig: {
+       readOnly: true
+   }
+
+And when read-only as the default, you can still override this setting for individual cells using `data-readonly`:
+
+.. code-block:: html
+
+   <pre data-executable data-readonly="false">print("I still can be modified")</pre>
+   <pre data-executable>print("Due to codeMirrorConfig, I cannot be modified")</pre>

--- a/docs/configure.rst
+++ b/docs/configure.rst
@@ -158,7 +158,7 @@ press the "run" button to see the outputs.
    }
 
 This uses codeMirror to mark all cells as read-only. If you are using this setting and would like to
-manually mark cells as editable, you can override the codeMirror configuration for individual cells using `data-readonly="false"`. For example:
+manually mark individual cells as editable, you can override the codeMirror configuration for a cell using `data-readonly="false"`. For example:
 
 .. code-block:: html
 

--- a/docs/configure.rst
+++ b/docs/configure.rst
@@ -158,7 +158,7 @@ press the "run" button to see the outputs.
    }
 
 This uses codeMirror to mark all cells as read-only. If you are using this setting and would like to
-manually mark individual cells as editable, you can override the codeMirror configuration for a cell using `data-readonly="false"`. For example:
+manually mark individual cells as editable, you can override the codeMirror configuration for a cell using ``data-readonly="false"``. For example:
 
 .. code-block:: html
 

--- a/docs/configure.rst
+++ b/docs/configure.rst
@@ -149,7 +149,7 @@ may mark it as "read-only" with the following syntax:
 Users will not be able to modify the code once Thebe is activated, though they can still
 press the "run" button to see the outputs.
 
-Alternatively, you can use the codeMirrorConfig in order to set the default as read-only for all cells:
+**To set all cells as read-only by default**, use the following `thebe` configuration:
 
 .. code:: javascript
 
@@ -157,7 +157,8 @@ Alternatively, you can use the codeMirrorConfig in order to set the default as r
        readOnly: true
    }
 
-And when read-only as the default, you can still override this setting for individual cells using `data-readonly`:
+This uses codeMirror to mark all cells as read-only. If you are using this setting and would like to
+manually mark cells as editable, you can override the codeMirror configuration for individual cells using `data-readonly="false"`. For example:
 
 .. code-block:: html
 


### PR DESCRIPTION
- Mentions how read-only can be set as the default in codeMirrorConfig, as well as how to selectively override this using `data-readonly="false"`.
- Swapped some code blocks to `code:: javascript` for better highlighting.

Due to the higher complexity of this scenario, I need others to look this over and ensure it is straight forward and understandable.

Relates to #286 and #274 