### PR TITLE
Add ipympl example documentation

### DIFF
--- a/docs/examples/ipympl_example.rst
+++ b/docs/examples/ipympl_example.rst
@@ -67,6 +67,7 @@ Press the "Activate" button below to connect to a Jupyter server:
 
 .. raw:: html
 
+   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.css" integrity="sha512-5A8nwdMOWrSz20fDsjczgUidUBR8liPYU+WymTZP1lmY9G6Oc7HlZv156XqnsgNUzTyMefFTcsFH/tnJE/+xBg==" crossorigin="anonymous" />
    <script src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.4/require.min.js"></script>
 
    <button id="activateButton" style="width: 120px; height: 40px; font-size: 1.5em;">
@@ -92,6 +93,15 @@ Press the "Activate" button below to connect to a Jupyter server:
      }
    </script>
    <script src="https://unpkg.com/thebelab@latest/lib/index.js"></script>
+
+
+.. warning:: This cell is only required in the thebe documentation due to the way that ipympl's Binder container is setup. Do not add or execute it when working with ipympl yourself.
+
+.. raw:: html
+
+   <pre data-executable="true" data-language="python">
+   rm -r ipympl
+   </pre>
 
 2D plot
 -------

--- a/docs/examples/ipympl_example.rst
+++ b/docs/examples/ipympl_example.rst
@@ -1,0 +1,127 @@
+==============
+Ipympl Example
+==============
+
+Thebe can display output from ipympl_, which enables interactivity with matplotlib_.
+
+.. _ipympl: https://github.com/matplotlib/ipympl 
+.. _matplotlib: https://matplotlib.org/ 
+
+Setup
+=====
+
+Be sure to load require.js and Font Awesome 4 before any of your thebe activation code so that the
+matplotlib widgets can function. 
+
+.. code-block:: html
+
+   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.css" integrity="sha512-5A8nwdMOWrSz20fDsjczgUidUBR8liPYU+WymTZP1lmY9G6Oc7HlZv156XqnsgNUzTyMefFTcsFH/tnJE/+xBg==" crossorigin="anonymous" />
+   <script src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.4/require.min.js"></script>
+
+
+Configure thebe and load it:
+
+.. code-block:: html
+
+   <script type="text/x-thebe-config">
+     {
+       requestKernel: true,
+       binderOptions: {
+         repo: "matplotlib/ipympl",
+         ref: "0.5.8",
+         repoProvider: "github",
+       },
+     }
+   </script>
+   <script src="https://unpkg.com/thebelab@latest/lib/index.js"></script>
+
+Create a button to activate thebe:
+
+.. code-block:: html
+
+   <button id="activateButton" style="width: 120px; height: 40px; font-size: 1.5em;">
+     Activate
+   </button>
+   <script>
+   var bootstrapThebe = function() {
+       thebelab.bootstrap();
+   }
+   document.querySelector("#activateButton").addEventListener('click', bootstrapThebe)
+   </script>
+
+Now add  between these HTML tags:
+
+.. code-block:: html
+
+   <pre data-executable="true" data-language="python">
+   %matplotlib widget
+
+   </pre>
+
+Examples
+========
+
+Using ipympl, you can display a variety of interactive plots.
+
+Press the "Activate" button below to connect to a Jupyter server:
+
+.. raw:: html
+
+   <script src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.4/require.min.js"></script>
+
+   <button id="activateButton" style="width: 120px; height: 40px; font-size: 1.5em;">
+     Activate
+   </button>
+   <script>
+   var bootstrapThebe = function() {
+       thebelab.bootstrap();
+   }
+   document.querySelector("#activateButton").addEventListener('click', bootstrapThebe)
+   </script>
+
+.. raw:: html
+
+   <script type="text/x-thebe-config">
+     {
+       requestKernel: true,
+       binderOptions: {
+         repo: "matplotlib/ipympl",
+         ref: "0.5.8",
+         repoProvider: "github",
+       },
+     }
+   </script>
+   <script src="https://unpkg.com/thebelab@latest/lib/index.js"></script>
+
+2D plot
+-------
+
+.. raw:: html
+
+   <pre data-executable="true" data-language="python">
+   %matplotlib widget
+
+   import matplotlib.pyplot as plt
+   
+   fig, ax = plt.subplots()
+   fig.canvas.layout.width = '7in'
+   fig.canvas.layout.height= '5in'
+   ax.plot([1,2,3], [4,5,3])
+   </pre>
+
+3D plot
+-------
+
+.. raw:: html
+
+  <pre data-executable="true" data-language="python">
+  %matplotlib widget
+  
+  from mpl_toolkits.mplot3d import axes3d
+  
+  fig = plt.figure()
+  ax = fig.add_subplot(111, projection='3d')
+  X, Y, Z = axes3d.get_test_data(0.05)
+  ax.plot_wireframe(X, Y, Z, rstride=10, cstride=10)
+  plt.show()
+   </pre>

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -87,6 +87,7 @@ see how Thebe is used.
 
    examples/minimal_example
    examples/ipyleaflet_example
+   examples/ipympl_example
    examples/plotly-example
 
 * `Making use of Jupyter interactive widgets <_static/widgets.html>`_


### PR DESCRIPTION
There is an error I'm running into from using the ipympl github repo as the Binder repo:
Regarding #185 
```
---------------------------------------------------------------------------
FileNotFoundError                         Traceback (most recent call last)
<ipython-input-1-38257e2684a4> in <module>
----> 1 get_ipython().run_line_magic('matplotlib', 'widget')
      2 import matplotlib.pyplot as plt
      3 fig, ax = plt.subplots()
      4 fig.canvas.layout.width = '7in'
      5 fig.canvas.layout.height= '5in'

/srv/conda/envs/notebook/lib/python3.7/site-packages/IPython/core/interactiveshell.py in run_line_magic(self, magic_name, line, _stack_depth)
   2305                 kwargs['local_ns'] = sys._getframe(stack_depth).f_locals
   2306             with self.builtin_trap:
-> 2307                 result = fn(*args, **kwargs)
   2308             return result
   2309 

</srv/conda/envs/notebook/lib/python3.7/site-packages/decorator.py:decorator-gen-108> in matplotlib(self, line)

/srv/conda/envs/notebook/lib/python3.7/site-packages/IPython/core/magic.py in <lambda>(f, *a, **k)
    185     # but it's overkill for just that one bit of state.
    186     def magic_deco(arg):
--> 187         call = lambda f, *a, **k: f(*a, **k)
    188 
    189         if callable(arg):

/srv/conda/envs/notebook/lib/python3.7/site-packages/IPython/core/magics/pylab.py in matplotlib(self, line)
     97             print("Available matplotlib backends: %s" % backends_list)
     98         else:
---> 99             gui, backend = self.shell.enable_matplotlib(args.gui.lower() if isinstance(args.gui, str) else args.gui)
    100             self._show_matplotlib_backend(args.gui, backend)
    101 

/srv/conda/envs/notebook/lib/python3.7/site-packages/IPython/core/interactiveshell.py in enable_matplotlib(self, gui)
   3405                 gui, backend = pt.find_gui_and_backend(self.pylab_gui_select)
   3406 
-> 3407         pt.activate_matplotlib(backend)
   3408         pt.configure_inline_support(self, backend)
   3409 

/srv/conda/envs/notebook/lib/python3.7/site-packages/IPython/core/pylabtools.py in activate_matplotlib(backend)
    314     # when this function runs.
    315     # So avoid needing matplotlib attribute-lookup to access pyplot.
--> 316     from matplotlib import pyplot as plt
    317 
    318     plt.switch_backend(backend)

/srv/conda/envs/notebook/lib/python3.7/site-packages/matplotlib/pyplot.py in <module>
   2280     dict.__setitem__(rcParams, "backend", rcsetup._auto_backend_sentinel)
   2281 # Set up the backend.
-> 2282 switch_backend(rcParams["backend"])
   2283 
   2284 # Just to be safe.  Interactive mode can be turned on without

/srv/conda/envs/notebook/lib/python3.7/site-packages/matplotlib/pyplot.py in switch_backend(newbackend)
    219         else "matplotlib.backends.backend_{}".format(newbackend.lower()))
    220 
--> 221     backend_mod = importlib.import_module(backend_name)
    222     Backend = type(
    223         "Backend", (matplotlib.backends._Backend,), vars(backend_mod))

/srv/conda/envs/notebook/lib/python3.7/importlib/__init__.py in import_module(name, package)
    125                 break
    126             level += 1
--> 127     return _bootstrap._gcd_import(name[level:], package, level)
    128 
    129 

~/ipympl/backend_nbagg.py in <module>
     25 
     26 here = os.path.dirname(__file__)
---> 27 with open(os.path.join(here, 'static', 'package.json')) as fid:
     28     js_semver = '^%s' % json.load(fid)['version']
     29 

FileNotFoundError: [Errno 2] No such file or directory: '/home/jovyan/ipympl/static/package.json'
```