### PR TITLE
Squash readOnly base-case tests to a single test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -82,6 +82,7 @@ jobs:
       - name: "Run tests"
         run: |
           npm test
+          npm run test:jest
 
       # Action Repo: https://github.com/codecov/codecov-action
       - name: "Upload coverage to codecov"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Thebe: turn static HTML pages into live documents
+![test](https://github.com/executablebooks/thebe/workflows/test/badge.svg)
 
 Have a static HTML page with code snippets? Your readers can edit and execute them right there. All it takes is:
 - A brief header in the HTML page

--- a/package-lock.json
+++ b/package-lock.json
@@ -15118,9 +15118,9 @@
       "dev": true
     },
     "puppeteer": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-5.4.0.tgz",
-      "integrity": "sha512-LgTqVW2ClEP4XGAT64FLQ0QWVhdNSRwJp9HfMFVfoJlZHGQu3HUbuBhR1hBow3DXZH1K3b/WfHxt1n8hr2uayw==",
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-5.4.1.tgz",
+      "integrity": "sha512-8u6r9tFm3gtMylU4uCry1W/CeAA8uczKMONvGvivkTsGqKA7iB7DWO2CBFYlB9GY6/IEoq9vkI5slJWzUBkwNw==",
       "dev": true,
       "requires": {
         "debug": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "mocha": "^8.2.0",
     "mocha-loader": "^5.1.5",
     "prettier": "^2.1.2",
-    "puppeteer": "^5.4.0",
+    "puppeteer": "^5.4.1",
     "style-loader": "^2.0.0",
     "url-loader": "^4.1.1",
     "webpack": "^4.0",

--- a/test/fixtures/HTML/readonly1.html
+++ b/test/fixtures/HTML/readonly1.html
@@ -27,19 +27,11 @@
 </head>
 <body>
 <div class="container">
-	<pre data-executable="true" data-language="python" class="pre-element" id="case-base-1">print("Hello!")</pre>
+	<pre data-executable="true" data-language="python" class="pre-element" id="case-noconfig">print("Hello!")</pre>
 	<pre data-executable="true" data-language="python" class="pre-element" id="case-standalone" data-readonly>print("standalone!")</pre>
 	<pre data-executable="true" data-language="python" class="pre-element" id="case-empty" data-readonly="">print("empty!")</pre>
 	<pre data-executable="true" data-language="python" class="pre-element" id="case-true" data-readonly="true">print("true!")</pre>
 	<pre data-executable="true" data-language="python" class="pre-element" id="case-false" data-readonly="false">print("false!")</pre>
-	<pre data-executable="true" data-language="python" class="pre-element" id="case-base-2">
-from IPython.display import Math
-Math("$x = 5$")
-            </pre>
-	<pre data-executable="true" data-language="python" class="pre-element" id="case-base-3">from ipywidgets import IntSlider
-w = IntSlider(0, 10)
-w
-            </pre>
 </div>
 </body>
 <style>

--- a/test/fixtures/HTML/readonly2.html
+++ b/test/fixtures/HTML/readonly2.html
@@ -28,19 +28,11 @@
 </head>
 <body>
 <div class="container">
-	<pre data-executable="true" data-language="python" class="pre-element" id="case-base-1">print("Hello!")</pre>
+	<pre data-executable="true" data-language="python" class="pre-element" id="case-noconfig">print("Hello!")</pre>
 	<pre data-executable="true" data-language="python" class="pre-element" id="case-standalone" data-readonly>print("standalone!")</pre>
 	<pre data-executable="true" data-language="python" class="pre-element" id="case-empty" data-readonly="">print("empty!")</pre>
 	<pre data-executable="true" data-language="python" class="pre-element" id="case-true" data-readonly="true">print("true!")</pre>
 	<pre data-executable="true" data-language="python" class="pre-element" id="case-false" data-readonly="false">print("false!")</pre>
-	<pre data-executable="true" data-language="python" class="pre-element" id="case-base-2">
-from IPython.display import Math
-Math("$x = 5$")
-            </pre>
-	<pre data-executable="true" data-language="python" class="pre-element" id="case-base-3">from ipywidgets import IntSlider
-w = IntSlider(0, 10)
-w
-            </pre>
 </div>
 </body>
 <style>

--- a/test/readonly.test.js
+++ b/test/readonly.test.js
@@ -36,16 +36,8 @@ describe("cells are default editable", () => {
     );
   });
 
-  test("case-base-1", async () => {
-    const isReadOnly = await page.evaluate(checkReadOnly, "#case-base-1");
-    expect(isReadOnly).toEqual(false);
-  });
-  test("case-base-2", async () => {
-    const isReadOnly = await page.evaluate(checkReadOnly, "#case-base-2");
-    expect(isReadOnly).toEqual(false);
-  });
-  test("case-base-3", async () => {
-    const isReadOnly = await page.evaluate(checkReadOnly, "#case-base-3");
+  test("case-noconfig", async () => {
+    const isReadOnly = await page.evaluate(checkReadOnly, "#case-noconfig");
     expect(isReadOnly).toEqual(false);
   });
   test("case-standalone", async () => {
@@ -79,16 +71,8 @@ describe("cells are default readonly", () => {
     );
   });
 
-  test("case-base-1", async () => {
-    const isReadOnly = await page.evaluate(checkReadOnly, "#case-base-1");
-    expect(isReadOnly).toEqual(true);
-  });
-  test("case-base-2", async () => {
-    const isReadOnly = await page.evaluate(checkReadOnly, "#case-base-2");
-    expect(isReadOnly).toEqual(true);
-  });
-  test("case-base-3", async () => {
-    const isReadOnly = await page.evaluate(checkReadOnly, "#case-base-3");
+  test("case-noconfig", async () => {
+    const isReadOnly = await page.evaluate(checkReadOnly, "#case-noconfig");
     expect(isReadOnly).toEqual(true);
   });
   test("case-standalone", async () => {


### PR DESCRIPTION
Reviewer indicated that the multiple `base-case` tests were confusing and did not improve testing capabilities. The three `base-case` test have been simplified into one test case of `noconfig`.