### PR TITLE
using local thebe in docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ coverage
 webpack.stats.*
 docs/_build
 /.idea/
+
+docs/_static/thebe

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -164,6 +164,7 @@ import shutil as sh
 
 if not Path("_static/thebe").exists():
     print("Couldn't find local `thebe` build, building now...")
+    run("npm install".split(), cwd="..")
     run("npm run build:prod".split(), cwd="..")
     sh.copytree("../lib", "_static/thebe")
 else:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -156,3 +156,15 @@ epub_exclude_files = ['search.html']
 
 # -- Linkcheck options ------------------
 linkcheck_anchors_ignore = ["/#!"]
+
+# -- Build the latest JS for local preview -----------------------------
+from subprocess import run
+from pathlib import Path
+import shutil as sh
+
+if not Path("_static/thebe").exists():
+    print("Couldn't find local `thebe` build, building now...")
+    run("npm run build:prod".split(), cwd="..")
+    sh.copytree("../lib", "_static/thebe")
+else:
+    print("Found local `thebe` build, to update it, delete `_static/thebe` and build docs")

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -169,7 +169,7 @@ if not Path("_static/thebe").exists():
         print("Dependencies for `thebe` not found, installing now...")
         # On READTHEDOCS we need the latest NPM in order to work
         if os.environ.get("READTHEDOCS"):
-            run("npm install npm@latest".split(), cwd="..")
+            run("npm install -g npm@latest".split(), cwd="..")
         run("npm install".split(), cwd="..")
     # Build the lib and move to the local folder for docs
     run("npm run build:prod".split(), cwd="..")

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -172,5 +172,6 @@ if not Path("_static/thebe").exists():
     # Build the lib and move to the local folder for docs
     run("npm run build:prod".split(), cwd=path_root)
     sh.copytree("../lib", "_static/thebe")
+    print("Finished building local `thebe` bundle.")
 else:
     print("Found local `thebe` build, to update it, delete `_static/thebe` and build docs")

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -167,9 +167,6 @@ if not Path("_static/thebe").exists():
     print("Couldn't find local `thebe` build for docs, building now...")
     if not Path("../node_modules").exists():
         print("Dependencies for `thebe` not found, installing now...")
-        # On READTHEDOCS we need the latest NPM in order to work
-        if os.environ.get("READTHEDOCS"):
-            run("npm install -g npm@latest".split(), cwd="..")
         run("npm install".split(), cwd="..")
     # Build the lib and move to the local folder for docs
     run("npm run build:prod".split(), cwd="..")

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -161,10 +161,17 @@ linkcheck_anchors_ignore = ["/#!"]
 from subprocess import run
 from pathlib import Path
 import shutil as sh
+import os
 
 if not Path("_static/thebe").exists():
-    print("Couldn't find local `thebe` build, building now...")
-    run("npm install".split(), cwd="..")
+    print("Couldn't find local `thebe` build for docs, building now...")
+    if not Path("../node_modules").exists():
+        print("Dependencies for `thebe` not found, installing now...")
+        # On READTHEDOCS we need the latest NPM in order to work
+        if os.environ.get("READTHEDOCS"):
+            run("npm install npm@latest".split(), cwd="..")
+        run("npm install".split(), cwd="..")
+    # Build the lib and move to the local folder for docs
     run("npm run build:prod".split(), cwd="..")
     sh.copytree("../lib", "_static/thebe")
 else:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -163,13 +163,14 @@ from pathlib import Path
 import shutil as sh
 import os
 
+path_root = Path(__file__).parent.parent
 if not Path("_static/thebe").exists():
     print("Couldn't find local `thebe` build for docs, building now...")
     if not Path("../node_modules").exists():
         print("Dependencies for `thebe` not found, installing now...")
-        run("npm install".split(), cwd="..")
+        run("npm install".split(), cwd=path_root)
     # Build the lib and move to the local folder for docs
-    run("npm run build:prod".split(), cwd="..")
+    run("npm run build:prod".split(), cwd=path_root)
     sh.copytree("../lib", "_static/thebe")
 else:
     print("Found local `thebe` build, to update it, delete `_static/thebe` and build docs")

--- a/docs/configure.rst
+++ b/docs/configure.rst
@@ -113,7 +113,7 @@ The below code cell demonstrates this theme:
        },
      }
    </script>
-   <script src="https://unpkg.com/thebelab@latest/lib/index.js"></script>
+   <script src="_static/thebe/index.js"></script>
 
    <pre data-executable="true" data-language="python">
    %matplotlib inline

--- a/docs/contribute.md
+++ b/docs/contribute.md
@@ -102,7 +102,7 @@ TODO: create some exemplar tests that:
 
 ## Building docs locally
 
-Thebe uses [Sphinx](https://www.sphinx-doc.org/) and [JupyterBook](https://jupyterbook.org/) for building documentation. Thebe documentation is located in the `/docs` directory.
+Thebe uses [Sphinx](https://www.sphinx-doc.org/) for building documentation. Thebe documentation is located in the `/docs` directory.
 You will need the development environment setup, see the above {ref}`dev-install` to learn more.
 You will also need Python installed, and can install the requirements for the documentation using:
 
@@ -115,6 +115,10 @@ Once you are in the documentation folder:
 
 ```bash
 make html
+```
+
+```{note}
+The first time that you run `make html`, `thebe` will be built and placed in the `_static/thebe` folder. This way, you use the latest version of thebe in previewing the documentation. If you'd like to update `thebe`, simply delete the `_static/thebe` folder and re-build the docs.
 ```
 
 Finally, run the following to view the built documentation locally:

--- a/docs/doc-requirements.txt
+++ b/docs/doc-requirements.txt
@@ -1,5 +1,5 @@
+sphinx>2
+myst_parser
 sphinx_copybutton
 sphinx_book_theme
 sphinx-js
-sphinx>2
-myst_parser

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -5,5 +5,8 @@ channels:
 dependencies:
   - nodejs
   - pip:
-    - -r doc-requirements.txt
-  
+    - sphinx>2
+    - myst_parser
+    - sphinx_copybutton
+    - sphinx_book_theme
+    - sphinx-js

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -3,6 +3,7 @@ name: docs
 channels:
   - conda-forge
 dependencies:
+  - pip
   - nodejs
   - sphinx
   - pip:

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -4,5 +4,6 @@ channels:
   - conda-forge
 dependencies:
   - nodejs
-  - -r doc-requirements.txt
+  - pip:
+    - -r doc-requirements.txt
   

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -4,5 +4,6 @@ channels:
   - conda-forge
 dependencies:
   - nodejs
+  - pip
   - pip:
     - -r doc-requirements.txt

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -4,6 +4,6 @@ channels:
   - conda-forge
 dependencies:
   - nodejs
-  - pip
+  - sphinx
   - pip:
     - -r doc-requirements.txt

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -1,0 +1,8 @@
+# This is only used by ReadTheDocs to ensure the latest node is installed
+name: docs
+channels:
+  - conda-forge
+dependencies:
+  - nodejs
+  - -r doc-requirements.txt
+  

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -5,8 +5,4 @@ channels:
 dependencies:
   - nodejs
   - pip:
-    - sphinx>2
-    - myst_parser
-    - sphinx_copybutton
-    - sphinx_book_theme
-    - sphinx-js
+    - -r doc-requirements.txt

--- a/docs/examples/bqplot_example.rst
+++ b/docs/examples/bqplot_example.rst
@@ -74,7 +74,7 @@ Example
        },
      }
    </script>
-   <script src="https://unpkg.com/thebelab@latest/lib/index.js"></script>
+   <script src="_static/thebe/index.js"></script>
 
 Press the "Activate" button below to connect to a Jupyter server:
 

--- a/docs/examples/ipyleaflet_example.rst
+++ b/docs/examples/ipyleaflet_example.rst
@@ -72,7 +72,7 @@ Example
        },
      }
    </script>
-   <script src="https://unpkg.com/thebelab@latest/lib/index.js"></script>
+   <script src="_static/thebe/index.js"></script>
 
 Press the "Activate" button below to connect to a Jupyter server:
 

--- a/docs/examples/minimal_example.rst
+++ b/docs/examples/minimal_example.rst
@@ -49,7 +49,7 @@ Next, we'll load Thebe from a CDN:
 
 .. raw:: html
 
-   <script src="https://unpkg.com/thebelab@latest/lib/index.js"></script>
+   <script src="_static/thebe/index.js"></script>
 
 .. code:: html
 

--- a/docs/examples/plotly-example.rst
+++ b/docs/examples/plotly-example.rst
@@ -69,7 +69,7 @@ Example
        },
      }
    </script>
-   <script src="https://unpkg.com/thebelab@latest/lib/index.js"></script>
+   <script src="_static/thebe/index.js"></script>
 
 Press the "Activate" button below to connect to a Jupyter server:
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -33,8 +33,8 @@ For example, see the following code cell:
        },
      }
    </script>
-   <script src="https://unpkg.com/thebelab@latest/lib/index.js"></script>
-
+   <script src="_static/thebe/index.js"></script>
+   
    <pre data-executable="true" data-language="python">
    %matplotlib inline
    import numpy as np

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,0 +1,4 @@
+version: 2
+
+conda:
+  environment: docs/environment.yml


### PR DESCRIPTION
An attempt at getting the latest thebe to work in our docs. This does the following things:

- In `conf.py` (so, whenever docs are built with Sphinx), check if `_static/thebe` exists.
- If not, then run `npm build:prod` and copy the `lib/` folder to `_static/thebe`
- In the docs, always link to `_static/thebe/index.js` when we load thebe (even though the `code-block` examples will show loading from the CDN)