### PR TITLE
📚 DOCS: Remove unnecessary code block from ipympl doc page

### DIFF
--- a/docs/examples/ipympl_example.rst
+++ b/docs/examples/ipympl_example.rst
@@ -28,7 +28,7 @@ Configure thebe and load it:
        requestKernel: true,
        binderOptions: {
          repo: "matplotlib/ipympl",
-         ref: "0.5.8",
+         ref: "0.6.1",
          repoProvider: "github",
        },
      }
@@ -87,21 +87,13 @@ Press the "Activate" button below to connect to a Jupyter server:
        requestKernel: true,
        binderOptions: {
          repo: "matplotlib/ipympl",
-         ref: "0.5.8",
+         ref: "0.6.1",
          repoProvider: "github",
        },
      }
    </script>
    <script src="https://unpkg.com/thebe@latest/lib/index.js"></script>
 
-
-.. warning:: This cell is only required in the thebe documentation due to the way that ipympl's Binder container is setup. Do not add or execute it when working with ipympl yourself.
-
-.. raw:: html
-
-   <pre data-executable="true" data-language="python">
-   rm -r ipympl
-   </pre>
 
 2D plot
 -------


### PR DESCRIPTION
Removes the code block, which previously removed the `ipympl` directory to run Thebe from the root directory of the repository. I don't think this is necessary anymore thanks to release 0.6.1 at ipympl: https://github.com/matplotlib/ipympl/pull/272

Preview of the new page: 
![image](https://user-images.githubusercontent.com/22624020/103603020-5c0e6000-4ec2-11eb-817f-fff60b038712.png)
