### PR TITLE
🐛 FIX: Should request kernel if needed when restartAndRunAll

### DIFF
--- a/src/thebelab.js
+++ b/src/thebelab.js
@@ -279,7 +279,7 @@ function renderCell(element, options) {
       window.thebelab.cells.map((idx, { setOutputText }) => setOutputText());
     }
     restart().then((kernel) => {
-      if (!kernel || !window.thebelab) return kernel;
+      if (!window.thebelab) return kernel;
       // Note, the jquery map is overridden, and is in the opposite order of native JS
       window.thebelab.cells.map((idx, { execute }) => execute());
       return kernel;


### PR DESCRIPTION
resolves #341 

### What is the problem?

When kernel is not requested yet, pressing `Restart and Run All` will hang in `Waiting for kernel` forever.

### What is expected?

Should go ahead and request a kernel and then run all.

### What is the fix?

Do not check if kernel exist in `restartAndRunAll()` since it will call `execute()` and that will do the job if a kernel is not there.