### PR TITLE
Ipycytoscape documentation repository --> 1.2.0

### DIFF
--- a/docs/examples/ipycytoscape_example.rst
+++ b/docs/examples/ipycytoscape_example.rst
@@ -27,7 +27,7 @@ Configure thebe and load it:
        requestKernel: true,
        binderOptions: {
          repo: "QuantStack/ipycytoscape",
-         ref: "1.0.4",
+         ref: "1.2.0",
          repoProvider: "github",
        },
      }


### PR DESCRIPTION
The current repository `QuantStack/ipycytoscape 1.0.4` seems to be broken on the [example page](https://thebelab.readthedocs.io/en/latest/examples/ipycytoscape_example.html) for Thebe. There are errors in console, and the widget does not display. This PR simply bumps the Thebe config in this documentation to a newer version of this repository, `1.2.0`, which I have confirmed works on local HTML pages. This tag runs on jupyterlab3 rather than 2.