### PR TITLE
1.2.0 Thebe config on ipycytoscape doc page

### DIFF
--- a/docs/examples/ipycytoscape_example.rst
+++ b/docs/examples/ipycytoscape_example.rst
@@ -86,7 +86,7 @@ Press the "Activate" button below to connect to a Jupyter server:
        requestKernel: true,
        binderOptions: {
          repo: "QuantStack/ipycytoscape",
-         ref: "1.0.4",
+         ref: "1.2.0",
          repoProvider: "github",
        },
      }


### PR DESCRIPTION
I changed the version for the repository in the regular HTML text but not in the actual configuration which is used for Thebe. This should fix that and make the example page work again. 