### PR TITLE
Make config example parseable

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ A full config script with defaults:
   predefinedOutput: false,
 
   // The selector for identifying whether an element should be treated as output
-  outputSelector: '[data-output]'
+  outputSelector: '[data-output]',
 
   // Options for requesting a notebook server from mybinder.org
   binderOptions: {

--- a/docs/howto/initialize_cells.rst
+++ b/docs/howto/initialize_cells.rst
@@ -31,7 +31,7 @@ simulates a click on the button.
            const initButton = cell.querySelector('.thebelab-run-button');
            initButton.click();
        });
-   }
+   });
 
 Running custom code with Thebe
 ==============================
@@ -46,7 +46,7 @@ once it is ready.
    thebelab.events.on("request-kernel")((kernel) => {
        // Find any cells with an initialization tag and ask Thebe to run them when ready
        kernel.requestExecute({code: "import numpy"})
-   }
+   });
 
 In both of the cases above, you'll likely need to customize the Javascript calls depending
 on how your code is structured and what behavior you'd like when users land on a page.

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,6 +1,6 @@
 # Examples of use of Thebe
 
-You can [browse them online](https://executablebooks.github.io/thebe/).
+You can [browse them online](https://thebe.readthedocs.io/en/latest/examples/minimal_example.html).
 To serve them locally instead, run:
 
     python -m http.server


### PR DESCRIPTION
Noticed a missing comma in configuration example. Just to save half a second for the next one who's going to copy/paste it.