### PR TITLE
temporarily disable dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,4 @@ updates:
     directory: "/" # Location of yarn.lock
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 0


### PR DESCRIPTION
Proposal to temporarily disable dependabot and consider dependency upgrades in one go ahead of releases in a more structured way.
