### PR TITLE
[MNT] library global object rename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.8.3 - To be confirmed
+
+### Deprecations
+
+- `thebe` has been added as an alias for `thebelab` and all css classes beginning with `thebelab-` duplicated as `thebe-`. The `thebelab` global object, exposed functions and user code reliant on css classes `thebelab-*`, will continue to work and any DOM elements created during operation will be decorated with `thebelab-` classes as expected, until removed in version 0.9.0.
+  [#230](https://github.com/executablebooks/thebe/issues/230)
+
 ## 0.8.2 - 2021-10-26
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -15,6 +15,12 @@ Thebe is a based on the [Jupyter](jupyter.org) technology, and thus supports [a 
 
 See [the Thebe Documentation](https://thebe.readthedocs.io/en/latest/) for more information. See also this [blog post](https://blog.ouseful.info/2017/12/18/run-python-code-embedded-in-html-via-a-jupyter-kernel/).
 
+**Deprecation Notice**
+
+> `thebe` has been added as an alias for `thebelab` and all css classes beginning with `thebelab-` duplicated as `thebe-` (as of 0.8.3).
+>
+> The `thebelab` global object, exposed functions and user code reliant on css classes `thebelab-*`, will continue to work and any DOM elements created during operation will be decorated with `thebelab-` classes as expected, until it is removed in version 0.9.0.
+
 ## How Thebe works
 
 Starting Thebe involves the following steps:

--- a/development/main.css
+++ b/development/main.css
@@ -25,6 +25,7 @@ body {
   margin-top: 8px;
   margin-bottom: 8px;
 }
+.thebe-cell,
 .thebelab-cell {
   width: 50vw;
 }

--- a/docs/_static/html_examples/demo-launch-button.html
+++ b/docs/_static/html_examples/demo-launch-button.html
@@ -23,9 +23,8 @@
         // Load the Thebe library
         $.getScript("https://unpkg.com/thebe@latest")
           .done(function (script, textStatus) {
-            console.log(thebelab);
-            thebelab.mountStatusWidget();
-            thebelab.bootstrap();
+            thebe.mountStatusWidget();
+            thebe.bootstrap();
             $("#launch-button").remove();
           })
           .fail(function (jqxhr, settings, exception) {

--- a/docs/_static/html_examples/demo-status-widget.html
+++ b/docs/_static/html_examples/demo-status-widget.html
@@ -39,8 +39,8 @@
       <h1>Using the built in Status Widget</h1>
       <p>
         It's possible to create your own status widget just by listening to
-        "status" events from thebelab, but the library also includes an easy to
-        use status widget, with minimal styling that you can add to you page.
+        "status" events from thebe, but the library also includes an easy to use
+        status widget, with minimal styling that you can add to you page.
       </p>
       <p>
         To add the widget. just add an element with the
@@ -48,7 +48,7 @@
       </p>
       <p>
         And set <code>mountStatusWidget:true</code> to the
-        <code>thebelab</code> options.
+        <code>thebe</code> options.
       </p>
       <div class="thebe-status"></div>
       <p>This cell will turn into the live cell:</p>

--- a/docs/_static/html_examples/index.css
+++ b/docs/_static/html_examples/index.css
@@ -3,7 +3,7 @@ body {
   max-width: 850px;
   font-family: sans-serif;
 }
-.thebelab-cell {
+.thebe-cell {
   max-width: 80ex;
   margin: auto;
 }

--- a/docs/_static/html_examples/status/thebe_status_field.js
+++ b/docs/_static/html_examples/status/thebe_status_field.js
@@ -24,11 +24,11 @@ function thebe_place_status_field() {
 
 function thebe_activate_cells() {
   // Download thebe
-  thebelab.on("status", function (evt, data) {
+  thebe.on("status", function (evt, data) {
     console.log("Status changed:", data.status, data.message);
     $(".thebe-status-field")
       .attr("class", "thebe-status-field thebe-status-" + data.status)
       .text(data.status);
   });
-  thebelab.bootstrap();
+  thebe.bootstrap();
 }

--- a/docs/_static/html_examples/widgets.html
+++ b/docs/_static/html_examples/widgets.html
@@ -31,8 +31,8 @@
     </p>
 
     <p>
-      This requires adding a script tag to load requirejs on page, for thebelab
-      to be able to load the JavaScript assets for custom widgets.
+      This requires adding a script tag to load requirejs on page, for thebe to
+      be able to load the JavaScript assets for custom widgets.
     </p>
 
     <pre data-executable="true" data-language="python">

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -10,4 +10,4 @@ The thebe JavaScript API
     We need to add jsdoc-style docstrings to our exported functions.
 
 
-.. js:autofunction:: thebelab.bootstrap
+.. js:autofunction:: thebe.bootstrap

--- a/docs/events.rst
+++ b/docs/events.rst
@@ -1,7 +1,7 @@
 Event hooks in Thebe
 ====================
 
-When Thebe is launched (with ``thebelab.bootstrap``), it will emit a series
+When Thebe is launched (with ``thebe.bootstrap``), it will emit a series
 of events corresponding to the state of the launch process. You can plug into
 these events to control the behavior on your page.
 
@@ -9,7 +9,7 @@ To do so, use the ``status`` event within Thebe, like so:
 
 .. code-block:: javascript
 
-       thebelab.on("status", function (evt, data) {
+       thebe.on("status", function (evt, data) {
         console.log("Status changed:", data.status, data.message);
     });
 

--- a/docs/examples/bqplot_example.rst
+++ b/docs/examples/bqplot_example.rst
@@ -45,7 +45,7 @@ Create a button to activate thebe:
    </button>
    <script>
    var bootstrapThebe = function() {
-       thebelab.bootstrap();
+       thebe.bootstrap();
    }
    document.querySelector("#activateButton").addEventListener('click', bootstrapThebe)
    </script>
@@ -85,7 +85,7 @@ Press the "Activate" button below to connect to a Jupyter server:
    </button>
    <script>
    var bootstrapThebe = function() {
-       thebelab.bootstrap();
+       thebe.bootstrap();
    }
    document.querySelector("#activateButton").addEventListener('click', bootstrapThebe)
    </script>

--- a/docs/examples/custom_activate_button.rst
+++ b/docs/examples/custom_activate_button.rst
@@ -5,7 +5,7 @@ Custom activate button
 ======================
 
 There are many ways you can activate Thebe. In this case, we'll add a
-custom button to our page, instead of using the built in UI widgets and
+custom button to our page (instead of using the built in UI widgets) and
 configure it to **bootstrap** Thebe once it is clicked.
 
 As before we setup Thebe with a basic configuration.

--- a/docs/examples/custom_activate_button.rst
+++ b/docs/examples/custom_activate_button.rst
@@ -1,0 +1,91 @@
+.. _custom_activate_button:
+
+======================
+Custom activate button
+======================
+
+There are many ways you can activate Thebe. In this case, we'll add a
+custom button to our page, instead of using the built in UI widgets and
+configure it to **bootstrap** Thebe once it is clicked.
+
+As before we setup Thebe with a basic configuration.
+
+.. raw:: html
+
+   <!-- Configure and load Thebe !-->
+   <script type="text/x-thebe-config">
+     {
+       requestKernel: true,
+       binderOptions: {
+         repo: "binder-examples/requirements",
+       },
+     }
+   </script>
+
+.. code:: html
+
+   <!-- Configure and load Thebe !-->
+   <script type="text/x-thebe-config">
+     {
+       requestKernel: true,
+       binderOptions: {
+         repo: "binder-examples/requirements",
+       },
+     }
+   </script>
+
+Then we'll load Thebe from a CDN:
+
+.. raw:: html
+
+   <script src="../_static/lib/index.js"></script>
+
+.. code:: html
+
+   <script src="https://unpkg.com/thebe@latest/lib/index.js"></script>
+
+Adding a custom button to activate Thebe
+========================================
+
+In order to add a custom button, we add a little bit of Javascript.
+
+.. raw:: html
+
+   <button id="activateButton" style="width: 150px; height: 75px; font-size: 1.5em; background-color: darkseagreen;">Activate</button>
+   <script>
+   var bootstrapThebe = function() {
+       thebe.bootstrap();
+   }
+
+   document.querySelector("#activateButton").addEventListener('click', bootstrapThebe)
+   </script>
+
+Placing the button and adding the JavaScript to enable Thebe was done with the
+code below:
+
+.. code:: html
+
+   <button id="activateButton"  style="width: 150px; height: 75px; font-size: 1.5em;">Activate</button>
+   <script>
+   var bootstrapThebe = function() {
+       thebe.bootstrap();
+   }
+
+   document.querySelector("#activateButton").addEventListener('click', bootstrapThebe)
+   </script>
+
+When we press activate, Thebe will bootstrap following code cell should render with controls.
+The Cell can be run and will execute when the kernel becomes available.
+
+.. raw:: html
+
+   <pre data-executable="true" data-language="python">print("Hello!")</pre>
+
+Here's the code that created the cell above:
+
+.. code:: html
+
+   <pre data-executable="true" data-language="python">print("Hello!")</pre>
+
+
+For more examples, check out :ref:`more_examples`.

--- a/docs/examples/ipycytoscape_example.rst
+++ b/docs/examples/ipycytoscape_example.rst
@@ -43,7 +43,7 @@ Create a button to activate thebe:
    </button>
    <script>
    var bootstrapThebe = function() {
-       thebelab.bootstrap();
+       thebe.bootstrap();
    }
    document.querySelector("#activateButton").addEventListener('click', bootstrapThebe)
    </script>
@@ -74,7 +74,7 @@ Press the "Activate" button below to connect to a Jupyter server:
    </button>
    <script>
    var bootstrapThebe = function() {
-       thebelab.bootstrap();
+       thebe.bootstrap();
    }
    document.querySelector("#activateButton").addEventListener('click', bootstrapThebe)
    </script>

--- a/docs/examples/ipyleaflet_example.rst
+++ b/docs/examples/ipyleaflet_example.rst
@@ -44,7 +44,7 @@ Create a button to activate thebe:
    </button>
    <script>
    var bootstrapThebe = function() {
-       thebelab.bootstrap();
+       thebe.bootstrap();
    }
    document.querySelector("#activateButton").addEventListener('click', bootstrapThebe)
    </script>
@@ -83,7 +83,7 @@ Press the "Activate" button below to connect to a Jupyter server:
    </button>
    <script>
    var bootstrapThebe = function() {
-       thebelab.bootstrap();
+       thebe.bootstrap();
    }
    document.querySelector("#activateButton").addEventListener('click', bootstrapThebe)
    </script>

--- a/docs/examples/ipympl_example.rst
+++ b/docs/examples/ipympl_example.rst
@@ -44,7 +44,7 @@ Create a button to activate thebe:
    </button>
    <script>
    var bootstrapThebe = function() {
-       thebelab.bootstrap();
+       thebe.bootstrap();
    }
    document.querySelector("#activateButton").addEventListener('click', bootstrapThebe)
    </script>
@@ -75,7 +75,7 @@ Press the "Activate" button below to connect to a Jupyter server:
    </button>
    <script>
    var bootstrapThebe = function() {
-       thebelab.bootstrap();
+       thebe.bootstrap();
    }
    document.querySelector("#activateButton").addEventListener('click', bootstrapThebe)
    </script>

--- a/docs/examples/matplotlib_interact_example.rst
+++ b/docs/examples/matplotlib_interact_example.rst
@@ -39,7 +39,7 @@ Create a button to activate thebe:
    </button>
    <script>
    var bootstrapThebe = function() {
-       thebelab.bootstrap();
+       thebe.bootstrap();
    }
    document.querySelector("#activateButton").addEventListener('click', bootstrapThebe)
    </script>
@@ -78,7 +78,7 @@ Press the "Activate" button below to connect to a Jupyter server:
    </button>
    <script>
    var bootstrapThebe = function() {
-       thebelab.bootstrap();
+       thebe.bootstrap();
    }
    document.querySelector("#activateButton").addEventListener('click', bootstrapThebe)
    </script>

--- a/docs/examples/minimal_example.rst
+++ b/docs/examples/minimal_example.rst
@@ -15,6 +15,10 @@ Loading and configuring Thebe
 In order to use Thebe, we must first set its configuration. This must be
 done **before** Thebe is loaded from a CDN or a local script.
 
+There are many ways you can activate Thebe. In this case, we'll add a
+button to our page, using the built in UI widgets, this will **bootstrap**
+Thebe once clicked. We'll do this with a little bit of Javascript.
+
 Here's a sample configuration for Thebe
 
 .. raw:: html
@@ -23,6 +27,8 @@ Here's a sample configuration for Thebe
    <script type="text/x-thebe-config">
      {
        requestKernel: true,
+       mountActivateWidget: true,
+       mountStatusWidget: true,
        binderOptions: {
          repo: "binder-examples/requirements",
        },
@@ -34,10 +40,12 @@ Here's a sample configuration for Thebe
    <!-- Configure and load Thebe !-->
    <script type="text/x-thebe-config">
      {
-       requestKernel: true,
-       binderOptions: {
+         requestKernel: true,
+         mountActivateWidget: true,
+         mountStatusWidget: true,
+         binderOptions: {
          repo: "binder-examples/requirements",
-       },
+         },
      }
    </script>
 
@@ -55,38 +63,32 @@ Next, we'll load Thebe from a CDN:
 
    <script src="https://unpkg.com/thebe@latest/lib/index.js"></script>
 
-Adding a button to activate Thebe
-=================================
 
-There are many ways you can activate Thebe. In this case, we'll add a
-button to our page, and configure it to **bootstrap** Thebe once it is
-clicked. We'll do this with a little bit of Javascript.
+Adding a Thebe UI widgets to your page
+======================================
+
+When the configuration options are set ot mount and activate button and status field you need
+to include mount points in your page which will be used to place the widgets. We can do this by
+adding the following `div` elements.
 
 .. raw:: html
 
-   <button id="activateButton" style="width: 150px; height: 75px; font-size: 1.5em;">Activate</button>
-   <script>
-   var bootstrapThebe = function() {
-       thebelab.bootstrap();
-   }
+   <style>
+      .thebe-activate, .thebe-status {
+         margin-bottom: 10px;
+      }
+   </style>
+   <div class="thebe-activate"></div>
+   <div class="thebe-status"></div>
 
-   document.querySelector("#activateButton").addEventListener('click', bootstrapThebe)
-   </script>
 
 Placing the button and adding the JavaScript to enable Thebe was done with the
 code below:
 
 .. code:: html
 
-   <button id="activateButton"  style="width: 150px; height: 45px; font-size: 1.5em;">Activate</button>
-   <script>
-   var bootstrapThebe = function() {
-       thebelab.bootstrap();
-   }
-
-   document.querySelector("#activateButton").addEventListener('click', bootstrapThebe)
-   </script>
-
+   <div class="thebe-activate""></div>
+   <div class="thebe-status"></div>
 
 Adding code cells
 =================

--- a/docs/examples/minimal_example.rst
+++ b/docs/examples/minimal_example.rst
@@ -67,9 +67,17 @@ Next, we'll load Thebe from a CDN:
 Adding a Thebe UI widgets to your page
 ======================================
 
-When the configuration options are set ot mount and activate button and status field you need
-to include mount points in your page which will be used to place the widgets. We can do this by
-adding the following `div` elements.
+When the configuration options are set to mount the activate button and status field, you will need
+to include mount points in your page which will be used to place the widgets.
+
+We can do this by adding the following `div` elements:
+
+.. code:: html
+
+   <div class="thebe-activate"></div>
+   <div class="thebe-status"></div>
+
+The following UI widgets are then mounted on the page.
 
 .. raw:: html
 
@@ -81,14 +89,7 @@ adding the following `div` elements.
    <div class="thebe-activate"></div>
    <div class="thebe-status"></div>
 
-
-Placing the button and adding the JavaScript to enable Thebe was done with the
-code below:
-
-.. code:: html
-
-   <div class="thebe-activate""></div>
-   <div class="thebe-status"></div>
+These widgets are minimally styled, but can be modified by overrriding or extending the following classes; `thebe-status`, `thebe-status-mounted`, `thebe-status-stub`, `thebe-status-field`, `thebe-status-message`, `thebe-status-building`, `thebe-status-launching`, `thebe-status-starting`, `thebe-status-ready`, `thebe-status-failed`, `thebe-status-busy`.
 
 Adding code cells
 =================

--- a/docs/examples/plotly-example.rst
+++ b/docs/examples/plotly-example.rst
@@ -42,7 +42,7 @@ Create a button to activate thebe:
    </button>
    <script>
    var bootstrapThebe = function() {
-       thebelab.bootstrap();
+       thebe.bootstrap();
    }
    document.querySelector("#activateButton").addEventListener('click', bootstrapThebe)
    </script>
@@ -80,7 +80,7 @@ Press the "Activate" button below to connect to a Jupyter server:
    </button>
    <script>
    var bootstrapThebe = function() {
-       thebelab.bootstrap();
+       thebe.bootstrap();
    }
    document.querySelector("#activateButton").addEventListener('click', bootstrapThebe)
    </script>

--- a/docs/examples/pythreejs-example.rst
+++ b/docs/examples/pythreejs-example.rst
@@ -43,7 +43,7 @@ Create a button to activate thebe:
    </button>
    <script>
    var bootstrapThebe = function() {
-       thebelab.bootstrap();
+       thebe.bootstrap();
    }
    document.querySelector("#activateButton").addEventListener('click', bootstrapThebe)
    </script>
@@ -82,7 +82,7 @@ Press the "Activate" button below to connect to a Jupyter server:
    </button>
    <script>
    var bootstrapThebe = function() {
-       thebelab.bootstrap();
+       thebe.bootstrap();
    }
    document.querySelector("#activateButton").addEventListener('click', bootstrapThebe)
    </script>

--- a/docs/howto/initialize_cells.rst
+++ b/docs/howto/initialize_cells.rst
@@ -23,12 +23,12 @@ simulates a click on the button.
 
 .. code-block:: javascript
 
-   thebelab.events.on("request-kernel")(() => {
+   thebe.events.on("request-kernel")(() => {
        // Find any cells with an initialization tag and ask Thebe to run them when ready
-       var thebeInitCells = document.querySelectorAll('.thebelab-init');
+       var thebeInitCells = document.querySelectorAll('.thebe-init');
        thebeInitCells.forEach((cell) => {
            console.log("Initializing Thebe with cell: " + cell.id);
-           const initButton = cell.querySelector('.thebelab-run-button');
+           const initButton = cell.querySelector('.thebe-run-button');
            initButton.click();
        });
    });
@@ -43,7 +43,7 @@ once it is ready.
 
 .. code-block:: javascript
 
-   thebelab.events.on("request-kernel")((kernel) => {
+   thebe.events.on("request-kernel")((kernel) => {
        // Find any cells with an initialization tag and ask Thebe to run them when ready
        kernel.requestExecute({code: "import numpy"})
    });

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -68,13 +68,10 @@ Getting Started
 
 To get started, check out :doc:`start`.
 
-.. DANGER::
-
-  References to `thebelab` will be removed in version 0.9.0.
+.. admonition:: References to `thebelab` will be removed in version 0.9.0
+  :class: warning
 
   As part of the library migration to an executable books project (`#230 <https://github.com/executablebooks/thebe/issues/230>`_), `thebe` has been added as an alias for `thebelab` and all css classes beginning with `thebelab-` duplicated as `thebe-`. The `thebelab` global object, exposed functions and user code reliant on css classes `thebelab-*`, will continue to work and any DOM elements created during operation will be decorated with `thebelab-` classes as expected, until removed in version 0.9.0.
-
-  Please migrate existing code to use the new `thebe` object and `thebe-*` css classes.
 
 .. _more_examples:
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -83,6 +83,7 @@ see how Thebe is used.
    :maxdepth: 1
 
    examples/minimal_example
+   examples/custom_activate_button
    examples/bqplot_example
    examples/ipyleaflet_example
    examples/ipympl_example
@@ -90,6 +91,7 @@ see how Thebe is used.
    examples/ipycytoscape_example
    examples/pythreejs-example
    examples/matplotlib_interact_example
+
 
 
 HTML based examples
@@ -104,7 +106,7 @@ HTML based examples
 * `Setting predefined output for cells <_static/html_examples/demo-preview.html>`_
 * `Example of a custom launch button, loading from unpgk.com <_static/html_examples/demo-launch-button.html>`_
 
-Source code for these examples can be found in `thebe/docs/_static/html_examples folder. <https://github.com/executablebooks/thebe/tree/master/examples>`_
+Source code for these examples can be found in `thebe/docs/_static/html_examples folder <https://github.com/executablebooks/thebe/tree/master/examples>`_
 
 .. ATTENTION:: Use the latest release of `thebe` on unpkg
   These examples build a _local_ version of `thebe` in order to show off the latest features.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -68,6 +68,13 @@ Getting Started
 
 To get started, check out :doc:`start`.
 
+.. DANGER::
+
+  References to `thebelab` will be removed in version 0.9.0.
+
+  As part of the library migration to an executable books project (`#230 <https://github.com/executablebooks/thebe/issues/230>`_), `thebe` has been added as an alias for `thebelab` and all css classes beginning with `thebelab-` duplicated as `thebe-`. The `thebelab` global object, exposed functions and user code reliant on css classes `thebelab-*`, will continue to work and any DOM elements created during operation will be decorated with `thebelab-` classes as expected, until removed in version 0.9.0.
+
+  Please migrate existing code to use the new `thebe` object and `thebe-*` css classes.
 
 .. _more_examples:
 
@@ -108,15 +115,17 @@ HTML based examples
 
 Source code for these examples can be found in `thebe/docs/_static/html_examples folder <https://github.com/executablebooks/thebe/tree/master/examples>`_
 
-.. ATTENTION:: Use the latest release of `thebe` on unpkg
-  These examples build a _local_ version of `thebe` in order to show off the latest features.
+.. IMPORTANT::
+  All examples build a _local_ version of `thebe` in order to show off the latest features.
   If you'd like to instead load the latest _release_ of Thebe, replace the `<script>` elements with the following:
 
   ```html
   <script type="text/javascript" src="https://unpkg.com/thebe@latest"></script>
   ```
 
-  Serve these examples indepenently by running `yarn serve:examples` in your local development environment.
+.. IMPORTANT::
+
+  Serve the HTML examples indepenently by running `yarn serve:examples` in your local development environment.
 
 External Examples
 -----------------

--- a/docs/start.rst
+++ b/docs/start.rst
@@ -43,7 +43,7 @@ Bootstrap Thebe on the page
 If the Thebe Javascript bundle is loaded, and the configuration file is present,
 you may bootstrap (i.e., launch) Thebe by calling the following Javascript function:
 
-``thebelab.bootstrap()``
+``thebe.bootstrap()``
 
 This will take one or more of the following actions:
 

--- a/docs/ui.rst
+++ b/docs/ui.rst
@@ -31,7 +31,7 @@ The following Keyboard shortcuts are active in code cells:
 Activate Button
 ===============
 
-When this button is pressed, it will run the `thebelab.bootstrap` function on the page.
+When this button is pressed, it will run the `thebe.bootstrap` function on the page.
 Configure this UI element as follows.
 
 Add a ``div`` element to the page in the desired location.

--- a/e2e/fixtures/HTML/readonly1.html
+++ b/e2e/fixtures/HTML/readonly1.html
@@ -1,73 +1,112 @@
 <!DOCTYPE html>
 <html>
-<head>
-	<!-- Configure and load Thebe !-->
-	<!-- two config sections: first binder, second local
+  <head>
+    <!-- Configure and load Thebe !-->
+    <!-- two config sections: first binder, second local
 	switch which one has type="text/x-thebe-config"
 	to activate it
   -->
-	<title>readonly1</title>
-	<script
-			src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
-			integrity="sha256-4+XzXVhsDmqanXGHaHvgh1gMQKX40OUvDEBTu8JcmNs="
-			crossorigin="anonymous"></script>
-	<script type="text/x-thebe-config">
-          {
-            bootstrap: true,
-            binderOptions: {
-              repo: "binder-examples/requirements",
-              codeMirrorConfig: {
-                "theme": "abcdef"
-              },
-            },
-          }
-        
-	</script>
-	<script src="../../../lib/index.js"></script>
-</head>
-<body>
-<div class="container">
-	<pre data-executable="true" data-language="python" class="pre-element" id="case-noconfig">print("Hello!")</pre>
-	<pre data-executable="true" data-language="python" class="pre-element" id="case-standalone" data-readonly>print("standalone!")</pre>
-	<pre data-executable="true" data-language="python" class="pre-element" id="case-empty" data-readonly="">print("empty!")</pre>
-	<pre data-executable="true" data-language="python" class="pre-element" id="case-true" data-readonly="true">print("true!")</pre>
-	<pre data-executable="true" data-language="python" class="pre-element" id="case-false" data-readonly="false">print("false!")</pre>
-</div>
-</body>
-<style>
-	body {
-		margin: 0;
-	}
+    <title>readonly1</title>
+    <script
+      src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+      integrity="sha256-4+XzXVhsDmqanXGHaHvgh1gMQKX40OUvDEBTu8JcmNs="
+      crossorigin="anonymous"
+    ></script>
+    <script type="text/x-thebe-config">
+      {
+        bootstrap: true,
+        binderOptions: {
+          repo: "binder-examples/requirements",
+          codeMirrorConfig: {
+            "theme": "abcdef"
+          },
+        },
+      }
+    </script>
+    <script src="../../../lib/index.js"></script>
+  </head>
+  <body>
+    <div class="container">
+      <pre
+        data-executable="true"
+        data-language="python"
+        class="pre-element"
+        id="case-noconfig"
+      >
+print("Hello!")</pre
+      >
+      <pre
+        data-executable="true"
+        data-language="python"
+        class="pre-element"
+        id="case-standalone"
+        data-readonly
+      >
+print("standalone!")</pre
+      >
+      <pre
+        data-executable="true"
+        data-language="python"
+        class="pre-element"
+        id="case-empty"
+        data-readonly=""
+      >
+print("empty!")</pre
+      >
+      <pre
+        data-executable="true"
+        data-language="python"
+        class="pre-element"
+        id="case-true"
+        data-readonly="true"
+      >
+print("true!")</pre
+      >
+      <pre
+        data-executable="true"
+        data-language="python"
+        class="pre-element"
+        id="case-false"
+        data-readonly="false"
+      >
+print("false!")</pre
+      >
+    </div>
+  </body>
+  <style>
+    body {
+      margin: 0;
+    }
 
-	.container {
-		display: flex;
-		flex-direction: column;
-		justify-content: center;
-		align-items: center;
-		height: 100vh;
-	}
+    .container {
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      align-items: center;
+      height: 100vh;
+    }
 
-	#activateButton {
-		width: 130px;
-		height: 50px;
-		font-size: 1.25em;
-		border: 1px solid black;
-		border-radius: 5px;
-		background-color: lightblue;
-		text-transform: uppercase;
-	}
+    #activateButton {
+      width: 130px;
+      height: 50px;
+      font-size: 1.25em;
+      border: 1px solid black;
+      border-radius: 5px;
+      background-color: lightblue;
+      text-transform: uppercase;
+    }
 
-	.pre-element {
-		width: 50vw;
-		height: 20vh;
-		border: 2px solid #aaa;
-		border-radius: 4px;
-		margin-top: 8px;
-		margin-bottom: 8px;
-	}
+    .pre-element {
+      width: 50vw;
+      height: 20vh;
+      border: 2px solid #aaa;
+      border-radius: 4px;
+      margin-top: 8px;
+      margin-bottom: 8px;
+    }
 
-	.thebelab-cell {
-		width: 50vw;
-	}
-</style>
+    .thebe-cell {
+      width: 50vw;
+    }
+  </style>
 </html>

--- a/e2e/fixtures/HTML/readonly2.html
+++ b/e2e/fixtures/HTML/readonly2.html
@@ -1,74 +1,113 @@
 <!DOCTYPE html>
 <html>
-<head>
-	<!-- Configure and load Thebe !-->
-	<!-- two config sections: first binder, second local
+  <head>
+    <!-- Configure and load Thebe !-->
+    <!-- two config sections: first binder, second local
 	switch which one has type="text/x-thebe-config"
 	to activate it
   -->
-	<title>readonly1</title>
-	<script
-			src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
-			integrity="sha256-4+XzXVhsDmqanXGHaHvgh1gMQKX40OUvDEBTu8JcmNs="
-			crossorigin="anonymous"></script>
-	<script type="text/x-thebe-config">
-          {
-            bootstrap: true,
-            binderOptions: {
-              repo: "binder-examples/requirements",
-              codeMirrorConfig: {
-                "theme": "abcdef",
-                "readOnly":"false"
-              },
-            },
-          }
-        
-	</script>
-	<script src="../../../lib/index.js"></script>
-</head>
-<body>
-<div class="container">
-	<pre data-executable="true" data-language="python" class="pre-element" id="case-noconfig">print("Hello!")</pre>
-	<pre data-executable="true" data-language="python" class="pre-element" id="case-standalone" data-readonly>print("standalone!")</pre>
-	<pre data-executable="true" data-language="python" class="pre-element" id="case-empty" data-readonly="">print("empty!")</pre>
-	<pre data-executable="true" data-language="python" class="pre-element" id="case-true" data-readonly="true">print("true!")</pre>
-	<pre data-executable="true" data-language="python" class="pre-element" id="case-false" data-readonly="false">print("false!")</pre>
-</div>
-</body>
-<style>
-	body {
-		margin: 0;
-	}
+    <title>readonly1</title>
+    <script
+      src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+      integrity="sha256-4+XzXVhsDmqanXGHaHvgh1gMQKX40OUvDEBTu8JcmNs="
+      crossorigin="anonymous"
+    ></script>
+    <script type="text/x-thebe-config">
+      {
+        bootstrap: true,
+        binderOptions: {
+          repo: "binder-examples/requirements",
+          codeMirrorConfig: {
+            "theme": "abcdef",
+            "readOnly":"false"
+          },
+        },
+      }
+    </script>
+    <script src="../../../lib/index.js"></script>
+  </head>
+  <body>
+    <div class="container">
+      <pre
+        data-executable="true"
+        data-language="python"
+        class="pre-element"
+        id="case-noconfig"
+      >
+print("Hello!")</pre
+      >
+      <pre
+        data-executable="true"
+        data-language="python"
+        class="pre-element"
+        id="case-standalone"
+        data-readonly
+      >
+print("standalone!")</pre
+      >
+      <pre
+        data-executable="true"
+        data-language="python"
+        class="pre-element"
+        id="case-empty"
+        data-readonly=""
+      >
+print("empty!")</pre
+      >
+      <pre
+        data-executable="true"
+        data-language="python"
+        class="pre-element"
+        id="case-true"
+        data-readonly="true"
+      >
+print("true!")</pre
+      >
+      <pre
+        data-executable="true"
+        data-language="python"
+        class="pre-element"
+        id="case-false"
+        data-readonly="false"
+      >
+print("false!")</pre
+      >
+    </div>
+  </body>
+  <style>
+    body {
+      margin: 0;
+    }
 
-	.container {
-		display: flex;
-		flex-direction: column;
-		justify-content: center;
-		align-items: center;
-		height: 100vh;
-	}
+    .container {
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      align-items: center;
+      height: 100vh;
+    }
 
-	#activateButton {
-		width: 130px;
-		height: 50px;
-		font-size: 1.25em;
-		border: 1px solid black;
-		border-radius: 5px;
-		background-color: lightblue;
-		text-transform: uppercase;
-	}
+    #activateButton {
+      width: 130px;
+      height: 50px;
+      font-size: 1.25em;
+      border: 1px solid black;
+      border-radius: 5px;
+      background-color: lightblue;
+      text-transform: uppercase;
+    }
 
-	.pre-element {
-		width: 50vw;
-		height: 20vh;
-		border: 2px solid #aaa;
-		border-radius: 4px;
-		margin-top: 8px;
-		margin-bottom: 8px;
-	}
+    .pre-element {
+      width: 50vw;
+      height: 20vh;
+      border: 2px solid #aaa;
+      border-radius: 4px;
+      margin-top: 8px;
+      margin-bottom: 8px;
+    }
 
-	.thebelab-cell {
-		width: 50vw;
-	}
-</style>
+    .thebe-cell {
+      width: 50vw;
+    }
+  </style>
 </html>

--- a/e2e/readonly.test.js
+++ b/e2e/readonly.test.js
@@ -14,8 +14,8 @@ describe("Initialization check", () => {
   });
   test("should have CodeMirror initalized", async () => {
     const text = await page.evaluate(() => document.body.innerHTML);
-    // console.log(text);
-    expect(text).toContain('class="thebelab-cell"');
+    expect(text).toContain("thebe-cell");
+    expect(text).toContain("thebelab-cell");
   });
 });
 

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "identity-obj-proxy": "^3.0.0",
     "istanbul-instrumenter-loader": "^3.0.1",
     "jest": "^26.6.3",
-    "jest-puppeteer": "^4.4.0",
+    "jest-puppeteer": "^5.0.0",
     "jquery": "^3.5.1",
     "jquery-ui-bundle": "^1.12.1-migrate",
     "ncp": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@jupyterlab/mathjax2": "^3.0.0",
     "@jupyterlab/outputarea": "^3.0.0",
     "@jupyterlab/services": "^6.0.0",
-    "@jupyterlab/testutils": "^3.0.11",
+    "@jupyterlab/testutils": "^3.2.4",
     "@jupyterlab/theme-light-extension": "^3.0.0",
     "babel-jest": "^26.6.1",
     "babel-loader": "^8.1.0",

--- a/src/activate.js
+++ b/src/activate.js
@@ -8,7 +8,7 @@ export class ActivateWidget {
   mount() {
     const el = $(".thebe-activate");
     el.replaceWith(`<div class="thebe-activate">
-      <button type="button" class="thebe-activate-button" onclick="thebelab.bootstrap()">${this.title}</button>
+      <button type="button" class="thebe-activate-button" onclick="thebe.bootstrap()">${this.title}</button>
     </div>`);
   }
 }

--- a/src/index.css
+++ b/src/index.css
@@ -1,10 +1,12 @@
-.thebelab-cell {
+.thebelab-cell,
+.thebe-cell {
   border: 2px solid #aaa;
   border-radius: 4px;
   margin-top: 8px;
   margin-bottom: 8px;
 }
-.thebelab-cell:focus-within {
+.thebelab-cell:focus-within,
+.thebelab:focus-within {
   border-color: green;
 }
 
@@ -34,14 +36,16 @@
   display: none;
 }
 
-.thebelab-busy {
+.thebelab-busy,
+.thebe-busy {
   display: inline-block;
   vertical-align: middle;
   padding-left: 2px;
   visibility: hidden;
 }
 
-.thebelab-busy-spinner {
+.thebelab-busy-spinner,
+.thebe-busy-spinner {
   border: 2px solid #f3f3f3; /* Light grey */
   border-top: 2px solid #3498db; /* Blue */
   border-radius: 50%;

--- a/src/index.js
+++ b/src/index.js
@@ -1,22 +1,22 @@
-import * as thebelab from "./thebelab";
-export * from "./thebelab";
+import * as thebe from "./thebe";
+export * from "./thebe";
 export * from "./utils";
 import $ from "jquery";
 
 if (typeof window !== "undefined") {
-  window.thebelab = thebelab;
-  window.thebelab.$ = $;
+  window.thebelab = window.thebe = thebe;
+  window.thebelab.$ = window.thebe.$ = $;
 
   document.addEventListener("DOMContentLoaded", () => {
-    const options = thebelab.mergeOptions();
+    const options = thebe.mergeOptions();
     if (options.mountStatusWidget) {
-      thebelab.mountStatusWidget();
+      thebe.mountStatusWidget();
     }
     if (options.mountActivateWidget) {
-      thebelab.mountActivateWidget();
+      thebe.mountActivateWidget();
     }
     if (options["bootstrap"]) {
-      thebelab.bootstrap();
+      thebe.bootstrap();
     }
   });
 }

--- a/src/render.js
+++ b/src/render.js
@@ -46,7 +46,7 @@ export function renderCell(element, options) {
   // render a single cell
   // element should be a `<pre>` tag with some code in it
   let mergedOptions = mergeOptions({ options });
-  let $cell = $("<div class='thebelab-cell'/>");
+  let $cell = $("<div class='thebe-cell thebelab-cell'/>");
   let $element = $(element);
   let $output = $element.next(mergedOptions.outputSelector);
   let source = $element.text().trim();
@@ -74,11 +74,13 @@ export function renderCell(element, options) {
 
   $element.replaceWith($cell);
 
-  let $cm_element = $("<div class='thebelab-input'>");
+  let $cm_element = $("<div class='thebe-input thebelab-input'>");
   $cell.append($cm_element);
   if (mergedOptions.mountRunButton) {
     $cell.append(
-      $("<button class='thebelab-button thebelab-run-button'>")
+      $(
+        "<button class='thebe-button thebe-run-button thebelab-button thebelab-run-button'>"
+      )
         .text("run")
         .attr("title", "run this cell")
         .click(execute)
@@ -86,7 +88,9 @@ export function renderCell(element, options) {
   }
   if (mergedOptions.mountRestartButton) {
     $cell.append(
-      $("<button class='thebelab-button thebelab-restart-button'>")
+      $(
+        "<button class='thebe-button thebe-restart-button thebelab-button thebelab-restart-button'>"
+      )
         .text("restart")
         .attr("title", "restart the kernel")
         .click(restart)
@@ -94,14 +98,18 @@ export function renderCell(element, options) {
   }
   if (mergedOptions.mountRestartallButton) {
     $cell.append(
-      $("<button class='thebelab-button thebelab-restartall-button'>")
+      $(
+        "<button class='thebe-button thebelab-button thebe-restartall-button thebelab-restartall-button'>"
+      )
         .text("restart & run all")
         .attr("title", "restart the kernel and run all cells")
         .click(restartAndRunAll)
     );
   }
   $cell.append(
-    $("<div class='thebelab-busy'><div class='thebelab-busy-spinner'></div>")
+    $(
+      "<div class='thebe-busy thebelab-busy'><div class='thebe-busy-spinner thebelab-busy-spinner'></div>"
+    )
   );
 
   let kernelResolve, kernelReject;
@@ -142,7 +150,7 @@ export function renderCell(element, options) {
       name: "stderr",
       text: `Failed to execute. ${error} Please refresh the page.`,
     });
-    $cell.find("div.thebelab-busy").css("visibility", "hidden");
+    $cell.find("div.thebe-busy").css("visibility", "hidden");
   }
 
   function getKernel() {
@@ -159,10 +167,10 @@ export function renderCell(element, options) {
     let code = cm.getValue();
     kernelPromise.then((kernel) => {
       try {
-        $cell.find(".thebelab-busy").css("visibility", "visible");
+        $cell.find(".thebe-busy").css("visibility", "visible");
         outputArea.future = kernel.requestExecute({ code: code });
         outputArea.future.done.then(() => {
-          $cell.find(".thebelab-busy").css("visibility", "hidden");
+          $cell.find(".thebe-busy").css("visibility", "hidden");
         });
       } catch (error) {
         clearOnError(error);
@@ -183,13 +191,13 @@ export function renderCell(element, options) {
   }
 
   function restartAndRunAll() {
-    if (window.thebelab) {
-      window.thebelab.cells.map((idx, { setOutputText }) => setOutputText());
+    if (window.thebe) {
+      thebe.cells.map((idx, { setOutputText }) => setOutputText());
     }
     restart().then((kernel) => {
-      if (!window.thebelab) return kernel;
+      if (!window.thebe) return kernel;
       // Note, the jquery map is overridden, and is in the opposite order of native JS
-      window.thebelab.cells.map((idx, { execute }) => execute());
+      window.thebe.cells.map((idx, { execute }) => execute());
       return kernel;
     });
   }

--- a/src/thebe.js
+++ b/src/thebe.js
@@ -45,13 +45,13 @@ export * from "./options";
 export * from "./events";
 
 export function mountStatusWidget() {
-  thebelab.kernelStatus = new KernelStatus(thebelab);
-  thebelab.kernelStatus.mount();
+  thebe.kernelStatus = new KernelStatus(thebe);
+  thebe.kernelStatus.mount();
 }
 
 export function mountActivateWidget() {
-  thebelab.activateButton = new ActivateWidget(thebelab);
-  thebelab.activateButton.mount();
+  thebe.activateButton = new ActivateWidget(thebe);
+  thebe.activateButton.mount();
 }
 
 /**
@@ -101,7 +101,7 @@ export function bootstrap(options) {
     });
   }
 
-  // bootstrap thebelab on the page
+  // bootstrap thebe on the page
   const cells = renderAllCells({
     selector: options.selector,
   });
@@ -114,6 +114,6 @@ export function bootstrap(options) {
 
     hookupKernel(kernel, cells, manager);
   });
-  if (window.thebelab) window.thebelab.cells = cells;
+  if (window.thebe) window.thebe.cells = cells;
   return kernelPromise;
 }

--- a/src/thebelab.js
+++ b/src/thebelab.js
@@ -16,7 +16,7 @@ if (typeof window !== "undefined") {
   window.CodeMirror = CodeMirror;
 }
 
-import "@jupyterlab/theme-light-extension/style/index.css";
+import "@jupyterlab/theme-light-extension/style/theme.css";
 import "@jupyter-widgets/controls/css/widgets-base.css";
 import "@lumino/widgets/style/index.css";
 import "@jupyterlab/apputils/style/base.css";

--- a/test/bootstrap.spec.js
+++ b/test/bootstrap.spec.js
@@ -1,4 +1,4 @@
-import * as thebelab from "../src/thebelab";
+import * as thebe from "../src/thebe";
 
 /**
  * Test the bootstrapping process
@@ -9,17 +9,17 @@ describe("bootstrap", () => {
   });
   it("calls pre-render hook", () => {
     const spy = jest.fn();
-    thebelab.bootstrap({ preRenderHook: spy }); // don't wait for kernel
+    thebe.bootstrap({ preRenderHook: spy }); // don't wait for kernel
     expect(spy).toHaveBeenCalledTimes(1);
   });
   it.skip("calls strip prompts, when specified in options", () => {
     const spy = jest.spyOn(thebelab, "stripPrompts");
 
-    thebelab.bootstrap();
-    expect(thebelab.stripPrompts).not.toHaveBeenCalled();
+    thebe.bootstrap();
+    expect(thebe.stripPrompts).not.toHaveBeenCalled();
 
-    thebelab.bootstrap({ stripPrompts: true });
-    expect(thebelab.stripPrompts).toHaveBeenCalled(1);
+    thebe.bootstrap({ stripPrompts: true });
+    expect(thebe.stripPrompts).toHaveBeenCalled(1);
 
     spy.mockRestore();
   });

--- a/test/render.spec.js
+++ b/test/render.spec.js
@@ -12,7 +12,7 @@ describe("rendering cells via bootstrap", () => {
     const p = thebe.bootstrap(); // don't wait for kernel
     expect(p.then).toBeDefined();
 
-    const cells = document.body.getElementsByClassName("thebelab-input");
+    const cells = document.body.getElementsByClassName("thebe-input");
     expect(cells.length).toEqual(1);
   });
   it("cell rendering (selector)", () => {
@@ -21,7 +21,7 @@ describe("rendering cells via bootstrap", () => {
     const p = thebe.bootstrap({ selector: ".mycode" }); // don't wait for kernel
     expect(p.then).toBeDefined();
 
-    const cells = document.body.getElementsByClassName("thebelab-input");
+    const cells = document.body.getElementsByClassName("thebe-input");
     expect(cells.length).toEqual(1);
   });
   it("output preview rendering (default)", () => {

--- a/test/thebe.properties.spec.js
+++ b/test/thebe.properties.spec.js
@@ -1,7 +1,8 @@
 import * as thebe from "../src";
 
 describe("properties", () => {
-  it("thebelab  is on window", () => {
+  it("thebe  is on window", () => {
+    expect(window.thebe).toBeDefined();
     expect(window.thebelab).toBeDefined();
   });
   it("should define events", () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1348,6 +1348,34 @@
     sanitize-html "~2.3.3"
     url "^0.11.0"
 
+"@jupyterlab/apputils@^3.2.4":
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/@jupyterlab/apputils/-/apputils-3.2.4.tgz#b6e786ebd217530c5d9aa489fbc8a5b4dc957a9e"
+  integrity sha512-x+lWYhmwR4nLHSiODtMidr//AoYhr7G/qSK16aV/shn5mgp7FWFViPpTGcCT//TQkuj+82N+azbMOIysZ2wOEw==
+  dependencies:
+    "@jupyterlab/coreutils" "^5.2.4"
+    "@jupyterlab/services" "^6.2.4"
+    "@jupyterlab/settingregistry" "^3.2.4"
+    "@jupyterlab/statedb" "^3.2.4"
+    "@jupyterlab/translation" "^3.2.4"
+    "@jupyterlab/ui-components" "^3.2.4"
+    "@lumino/algorithm" "^1.3.3"
+    "@lumino/commands" "^1.12.0"
+    "@lumino/coreutils" "^1.5.3"
+    "@lumino/disposable" "^1.4.3"
+    "@lumino/domutils" "^1.2.3"
+    "@lumino/messaging" "^1.4.3"
+    "@lumino/polling" "^1.3.3"
+    "@lumino/properties" "^1.2.3"
+    "@lumino/signaling" "^1.4.3"
+    "@lumino/virtualdom" "^1.8.0"
+    "@lumino/widgets" "^1.19.0"
+    "@types/react" "^17.0.0"
+    react "^17.0.1"
+    react-dom "^17.0.1"
+    sanitize-html "~2.3.3"
+    url "^0.11.0"
+
 "@jupyterlab/attachments@^3.2.1":
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/@jupyterlab/attachments/-/attachments-3.2.1.tgz#056867693f627ca34cf59342829f389062cc3ea1"
@@ -1357,6 +1385,18 @@
     "@jupyterlab/observables" "^4.2.1"
     "@jupyterlab/rendermime" "^3.2.1"
     "@jupyterlab/rendermime-interfaces" "^3.2.1"
+    "@lumino/disposable" "^1.4.3"
+    "@lumino/signaling" "^1.4.3"
+
+"@jupyterlab/attachments@^3.2.4":
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/@jupyterlab/attachments/-/attachments-3.2.4.tgz#53ffc7e06b1cc8f6ba4c0ae965db23738ab1a032"
+  integrity sha512-ZNzlhgSBeoYbWzIzzI+yPxJY744RrkGS3EvYNW4SZBFUGP+S0xaTD0PKC75JQu0laCubagEaiRhovoCkfS+dLA==
+  dependencies:
+    "@jupyterlab/nbformat" "^3.2.4"
+    "@jupyterlab/observables" "^4.2.4"
+    "@jupyterlab/rendermime" "^3.2.4"
+    "@jupyterlab/rendermime-interfaces" "^3.2.4"
     "@lumino/disposable" "^1.4.3"
     "@lumino/signaling" "^1.4.3"
 
@@ -1389,6 +1429,35 @@
     marked "^2.0.0"
     react "^17.0.1"
 
+"@jupyterlab/cells@^3.2.4":
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/@jupyterlab/cells/-/cells-3.2.4.tgz#7104f99c79a315f9a7aeead3c5df593ca36dbfbe"
+  integrity sha512-ttX83P2o7Vy5Lh4ohl/qWSn+exPo/rxmsD8itbqfFdonO2gqf4eQCNd20sHkunY+6WzA6eU6tqaMy7Ze9GKmdQ==
+  dependencies:
+    "@jupyterlab/apputils" "^3.2.4"
+    "@jupyterlab/attachments" "^3.2.4"
+    "@jupyterlab/codeeditor" "^3.2.4"
+    "@jupyterlab/codemirror" "^3.2.4"
+    "@jupyterlab/coreutils" "^5.2.4"
+    "@jupyterlab/filebrowser" "^3.2.4"
+    "@jupyterlab/nbformat" "^3.2.4"
+    "@jupyterlab/observables" "^4.2.4"
+    "@jupyterlab/outputarea" "^3.2.4"
+    "@jupyterlab/rendermime" "^3.2.4"
+    "@jupyterlab/services" "^6.2.4"
+    "@jupyterlab/shared-models" "^3.2.4"
+    "@jupyterlab/ui-components" "^3.2.4"
+    "@lumino/algorithm" "^1.3.3"
+    "@lumino/coreutils" "^1.5.3"
+    "@lumino/domutils" "^1.2.3"
+    "@lumino/dragdrop" "^1.7.1"
+    "@lumino/messaging" "^1.4.3"
+    "@lumino/signaling" "^1.4.3"
+    "@lumino/virtualdom" "^1.8.0"
+    "@lumino/widgets" "^1.19.0"
+    marked "^2.0.0"
+    react "^17.0.1"
+
 "@jupyterlab/codeeditor@^3.2.1":
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/@jupyterlab/codeeditor/-/codeeditor-3.2.1.tgz#f52312bb9895e94b0b022805df34088ae6b90f75"
@@ -1400,6 +1469,24 @@
     "@jupyterlab/shared-models" "^3.2.1"
     "@jupyterlab/translation" "^3.2.1"
     "@jupyterlab/ui-components" "^3.2.1"
+    "@lumino/coreutils" "^1.5.3"
+    "@lumino/disposable" "^1.4.3"
+    "@lumino/dragdrop" "^1.7.1"
+    "@lumino/messaging" "^1.4.3"
+    "@lumino/signaling" "^1.4.3"
+    "@lumino/widgets" "^1.19.0"
+
+"@jupyterlab/codeeditor@^3.2.4":
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/@jupyterlab/codeeditor/-/codeeditor-3.2.4.tgz#6190acfe08184c119273cd289eeec1bb9ebb48f3"
+  integrity sha512-h0PLQEuuth+y0Hz5jdj/aQSg3a4AFMnirTXIzbrP+YVLjLj7NzY12WKDukWayDd+SMQA+kHlbscO3lnWE7v89Q==
+  dependencies:
+    "@jupyterlab/coreutils" "^5.2.4"
+    "@jupyterlab/nbformat" "^3.2.4"
+    "@jupyterlab/observables" "^4.2.4"
+    "@jupyterlab/shared-models" "^3.2.4"
+    "@jupyterlab/translation" "^3.2.4"
+    "@jupyterlab/ui-components" "^3.2.4"
     "@lumino/coreutils" "^1.5.3"
     "@lumino/disposable" "^1.4.3"
     "@lumino/dragdrop" "^1.7.1"
@@ -1431,10 +1518,47 @@
     react "^17.0.1"
     y-codemirror "^2.1.1"
 
+"@jupyterlab/codemirror@^3.2.4":
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/@jupyterlab/codemirror/-/codemirror-3.2.4.tgz#732163be94911c2bcbffda600af7c7d01abbbf93"
+  integrity sha512-6ocnfoQtFO70KfnJhneOVCcxqTZrO+9vBF+MdoISEPKK03MPwM/9tRs0rPEvzHUE4xEN+1KjFEb/3pcHB6WZiQ==
+  dependencies:
+    "@jupyterlab/apputils" "^3.2.4"
+    "@jupyterlab/codeeditor" "^3.2.4"
+    "@jupyterlab/coreutils" "^5.2.4"
+    "@jupyterlab/nbformat" "^3.2.4"
+    "@jupyterlab/observables" "^4.2.4"
+    "@jupyterlab/shared-models" "^3.2.4"
+    "@jupyterlab/statusbar" "^3.2.4"
+    "@jupyterlab/translation" "^3.2.4"
+    "@lumino/algorithm" "^1.3.3"
+    "@lumino/commands" "^1.12.0"
+    "@lumino/coreutils" "^1.5.3"
+    "@lumino/disposable" "^1.4.3"
+    "@lumino/polling" "^1.3.3"
+    "@lumino/signaling" "^1.4.3"
+    "@lumino/widgets" "^1.19.0"
+    codemirror "~5.61.0"
+    react "^17.0.1"
+    y-codemirror "^3.0.1"
+
 "@jupyterlab/coreutils@^5.0.6", "@jupyterlab/coreutils@^5.1.1", "@jupyterlab/coreutils@^5.1.6", "@jupyterlab/coreutils@^5.2.1":
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/@jupyterlab/coreutils/-/coreutils-5.2.1.tgz#7f0cf4f16c15ad4a88cec912da19c05612a26ae4"
   integrity sha512-BryI6XgSFLprQ0a6BQ8oNdWb4nJYOJJN7VXc5N2XcZYkHb5L3yRMYIb7Aa8aMpuUAVrO2yijg4ItWh28GGXs1Q==
+  dependencies:
+    "@lumino/coreutils" "^1.5.3"
+    "@lumino/disposable" "^1.4.3"
+    "@lumino/signaling" "^1.4.3"
+    minimist "~1.2.0"
+    moment "^2.24.0"
+    path-browserify "^1.0.0"
+    url-parse "~1.5.1"
+
+"@jupyterlab/coreutils@^5.2.4":
+  version "5.2.4"
+  resolved "https://registry.yarnpkg.com/@jupyterlab/coreutils/-/coreutils-5.2.4.tgz#7cf858a35dc3076b77a7194c0abf1340564b1c39"
+  integrity sha512-0QXhg8R0bkb5LILhfphE/K5k4zJI8N+fNsmy/Nr4mDo8l8mB7km6OUcbSSNuJg1mYikOhEA+UxhqE0954UgxkQ==
   dependencies:
     "@lumino/coreutils" "^1.5.3"
     "@lumino/disposable" "^1.4.3"
@@ -1465,6 +1589,27 @@
     "@lumino/widgets" "^1.19.0"
     react "^17.0.1"
 
+"@jupyterlab/docmanager@^3.2.4":
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/@jupyterlab/docmanager/-/docmanager-3.2.4.tgz#860f87465cf054882f44f38fc76cf4caf08d308e"
+  integrity sha512-FVmwek2Bn9aO5Q9lgK9abDBxgC/3LMhjokrP9PG0bwJ+vSrGngX+MoAE3UuFOxWxMhzBQ2d7zh90ToAUVTCBrQ==
+  dependencies:
+    "@jupyterlab/apputils" "^3.2.4"
+    "@jupyterlab/coreutils" "^5.2.4"
+    "@jupyterlab/docprovider" "^3.2.4"
+    "@jupyterlab/docregistry" "^3.2.4"
+    "@jupyterlab/services" "^6.2.4"
+    "@jupyterlab/statusbar" "^3.2.4"
+    "@jupyterlab/translation" "^3.2.4"
+    "@lumino/algorithm" "^1.3.3"
+    "@lumino/coreutils" "^1.5.3"
+    "@lumino/disposable" "^1.4.3"
+    "@lumino/messaging" "^1.4.3"
+    "@lumino/properties" "^1.2.3"
+    "@lumino/signaling" "^1.4.3"
+    "@lumino/widgets" "^1.19.0"
+    react "^17.0.1"
+
 "@jupyterlab/docprovider@^3.2.1":
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/@jupyterlab/docprovider/-/docprovider-3.2.1.tgz#f187c39454891e58404bf4fbca754e7b0d1a7765"
@@ -1475,6 +1620,17 @@
     lib0 "^0.2.42"
     y-websocket "^1.3.15"
     yjs "^13.5.6"
+
+"@jupyterlab/docprovider@^3.2.4":
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/@jupyterlab/docprovider/-/docprovider-3.2.4.tgz#c9a6513f12d88ea059e14d2a7e61ad3a760e10f7"
+  integrity sha512-7yh9lJslZb9/kgKD4Jta8XWhBrdZXN+/g2XKbRtgpESWboJ0/YAgglhxk2O+7pLVzs9vMdZmqAMCHbwui9+ltA==
+  dependencies:
+    "@jupyterlab/shared-models" "^3.2.4"
+    "@lumino/coreutils" "^1.5.3"
+    lib0 "^0.2.42"
+    y-websocket "^1.3.15"
+    yjs "^13.5.17"
 
 "@jupyterlab/docregistry@^3.0.0", "@jupyterlab/docregistry@^3.0.11", "@jupyterlab/docregistry@^3.1.1", "@jupyterlab/docregistry@^3.2.1":
   version "3.2.1"
@@ -1501,6 +1657,31 @@
     "@lumino/widgets" "^1.19.0"
     yjs "^13.5.6"
 
+"@jupyterlab/docregistry@^3.2.4":
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/@jupyterlab/docregistry/-/docregistry-3.2.4.tgz#edfccd2ff87ecb69aa8c56768fe8f43d2fb3a09a"
+  integrity sha512-3RVZrRgudrUqebz6FIgF8vD0nQsn7zzgy72XwB5YkYa7FBdLTf875ehUFXX4MdxqJC/uM/1th+0RPnnl8OwvaA==
+  dependencies:
+    "@jupyterlab/apputils" "^3.2.4"
+    "@jupyterlab/codeeditor" "^3.2.4"
+    "@jupyterlab/codemirror" "^3.2.4"
+    "@jupyterlab/coreutils" "^5.2.4"
+    "@jupyterlab/docprovider" "^3.2.4"
+    "@jupyterlab/observables" "^4.2.4"
+    "@jupyterlab/rendermime" "^3.2.4"
+    "@jupyterlab/rendermime-interfaces" "^3.2.4"
+    "@jupyterlab/services" "^6.2.4"
+    "@jupyterlab/shared-models" "^3.2.4"
+    "@jupyterlab/translation" "^3.2.4"
+    "@jupyterlab/ui-components" "^3.2.4"
+    "@lumino/algorithm" "^1.3.3"
+    "@lumino/coreutils" "^1.5.3"
+    "@lumino/disposable" "^1.4.3"
+    "@lumino/messaging" "^1.4.3"
+    "@lumino/signaling" "^1.4.3"
+    "@lumino/widgets" "^1.19.0"
+    yjs "^13.5.17"
+
 "@jupyterlab/filebrowser@^3.2.1":
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/@jupyterlab/filebrowser/-/filebrowser-3.2.1.tgz#ac197b6b8e2a165b237b47bf80f84b255969c603"
@@ -1515,6 +1696,32 @@
     "@jupyterlab/statusbar" "^3.2.1"
     "@jupyterlab/translation" "^3.2.1"
     "@jupyterlab/ui-components" "^3.2.1"
+    "@lumino/algorithm" "^1.3.3"
+    "@lumino/coreutils" "^1.5.3"
+    "@lumino/disposable" "^1.4.3"
+    "@lumino/domutils" "^1.2.3"
+    "@lumino/dragdrop" "^1.7.1"
+    "@lumino/messaging" "^1.4.3"
+    "@lumino/polling" "^1.3.3"
+    "@lumino/signaling" "^1.4.3"
+    "@lumino/virtualdom" "^1.8.0"
+    "@lumino/widgets" "^1.19.0"
+    react "^17.0.1"
+
+"@jupyterlab/filebrowser@^3.2.4":
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/@jupyterlab/filebrowser/-/filebrowser-3.2.4.tgz#cb226ef6181a7a6fba31e84f20e90c50557cb676"
+  integrity sha512-BF6nEO+ppUCrQdJur/JEzio+jRZqgTwdqk1KARmwtFYJMcbaCVMTnaInD//xopSwhcNRLDOfOlA45T1llkH3qQ==
+  dependencies:
+    "@jupyterlab/apputils" "^3.2.4"
+    "@jupyterlab/coreutils" "^5.2.4"
+    "@jupyterlab/docmanager" "^3.2.4"
+    "@jupyterlab/docregistry" "^3.2.4"
+    "@jupyterlab/services" "^6.2.4"
+    "@jupyterlab/statedb" "^3.2.4"
+    "@jupyterlab/statusbar" "^3.2.4"
+    "@jupyterlab/translation" "^3.2.4"
+    "@jupyterlab/ui-components" "^3.2.4"
     "@lumino/algorithm" "^1.3.3"
     "@lumino/coreutils" "^1.5.3"
     "@lumino/disposable" "^1.4.3"
@@ -1573,7 +1780,14 @@
   dependencies:
     "@lumino/coreutils" "^1.5.3"
 
-"@jupyterlab/notebook@^3.0.0", "@jupyterlab/notebook@^3.2.1":
+"@jupyterlab/nbformat@^3.2.4":
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/@jupyterlab/nbformat/-/nbformat-3.2.4.tgz#dca9720804c949371d30227a8254de3b9feffc59"
+  integrity sha512-tEwt+vKAQEqj2smC8B5Myg693/5md3T9Nm3BM3Ix2NYqioCLlnGJ+aYQaOx1bsjyYWGLH/liW26O0NAUB3oEWg==
+  dependencies:
+    "@lumino/coreutils" "^1.5.3"
+
+"@jupyterlab/notebook@^3.0.0":
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/@jupyterlab/notebook/-/notebook-3.2.1.tgz#523bbaae0a08c9a1a9f7f9c1b56d51703f2d2de8"
   integrity sha512-8U3iHVJK1QF8xU1uKzPor88CSeh9ktuiOyuPeKqu6k7rWiT+GoBnjLz+ICvQtUNXzCnpsmmkGyB/jlNVFvZUGg==
@@ -1602,6 +1816,35 @@
     "@lumino/widgets" "^1.19.0"
     react "^17.0.1"
 
+"@jupyterlab/notebook@^3.2.4":
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/@jupyterlab/notebook/-/notebook-3.2.4.tgz#e3d946e601bf6df39fb00d69d3e7669eaa1fa15f"
+  integrity sha512-wth5JW5y90mZEhbYUY5WhWDNQ2kitNXiN6G4lPoA3V3alyAhax0N8WpRfOyd83CyCls9MtPhZM19ELWa0co4rg==
+  dependencies:
+    "@jupyterlab/apputils" "^3.2.4"
+    "@jupyterlab/cells" "^3.2.4"
+    "@jupyterlab/codeeditor" "^3.2.4"
+    "@jupyterlab/coreutils" "^5.2.4"
+    "@jupyterlab/docregistry" "^3.2.4"
+    "@jupyterlab/nbformat" "^3.2.4"
+    "@jupyterlab/observables" "^4.2.4"
+    "@jupyterlab/rendermime" "^3.2.4"
+    "@jupyterlab/services" "^6.2.4"
+    "@jupyterlab/shared-models" "^3.2.4"
+    "@jupyterlab/statusbar" "^3.2.4"
+    "@jupyterlab/translation" "^3.2.4"
+    "@jupyterlab/ui-components" "^3.2.4"
+    "@lumino/algorithm" "^1.3.3"
+    "@lumino/coreutils" "^1.5.3"
+    "@lumino/domutils" "^1.2.3"
+    "@lumino/dragdrop" "^1.7.1"
+    "@lumino/messaging" "^1.4.3"
+    "@lumino/properties" "^1.2.3"
+    "@lumino/signaling" "^1.4.3"
+    "@lumino/virtualdom" "^1.8.0"
+    "@lumino/widgets" "^1.19.0"
+    react "^17.0.1"
+
 "@jupyterlab/observables@^4.0.6", "@jupyterlab/observables@^4.1.1":
   version "4.1.6"
   resolved "https://registry.yarnpkg.com/@jupyterlab/observables/-/observables-4.1.6.tgz#0af551c2bd6c3991200c20ff9f630ee7c71a2f84"
@@ -1617,6 +1860,17 @@
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/@jupyterlab/observables/-/observables-4.2.1.tgz#28de93b1b3bcfd0f211a62ac9ed6db982660f065"
   integrity sha512-TRtL28+ly0Ww3nsUG0cE646eOVss0nT4oC/C/8UwAqRFK6uCy3maZhHKVsVo36OMkUIOvrv4Ln7ROajhPwUHkA==
+  dependencies:
+    "@lumino/algorithm" "^1.3.3"
+    "@lumino/coreutils" "^1.5.3"
+    "@lumino/disposable" "^1.4.3"
+    "@lumino/messaging" "^1.4.3"
+    "@lumino/signaling" "^1.4.3"
+
+"@jupyterlab/observables@^4.2.4":
+  version "4.2.4"
+  resolved "https://registry.yarnpkg.com/@jupyterlab/observables/-/observables-4.2.4.tgz#77be638b9a8b660576087151e275b9e08239dd4a"
+  integrity sha512-9b1a2+Tmda/Jr8oLMpMhQJAEpMRgILo8unjTnpMCb9RZgOZAwMRs+vItNqrjrapa4OO1vhIFVRWWqmxa5vz/6Q==
   dependencies:
     "@lumino/algorithm" "^1.3.3"
     "@lumino/coreutils" "^1.5.3"
@@ -1684,6 +1938,26 @@
     "@lumino/widgets" "^1.19.0"
     resize-observer-polyfill "^1.5.1"
 
+"@jupyterlab/outputarea@^3.2.4":
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/@jupyterlab/outputarea/-/outputarea-3.2.4.tgz#12e1ec4127bdbbad34326de2ac976bb914e69785"
+  integrity sha512-+JU3bu8SNAURf7orofVBUWiaNtC2b7SSi/Gd6KpJ/c7CnK2XaPZ1BdHD+ioMcAZsGEkymrFcmIvzXTZjpImJDQ==
+  dependencies:
+    "@jupyterlab/apputils" "^3.2.4"
+    "@jupyterlab/nbformat" "^3.2.4"
+    "@jupyterlab/observables" "^4.2.4"
+    "@jupyterlab/rendermime" "^3.2.4"
+    "@jupyterlab/rendermime-interfaces" "^3.2.4"
+    "@jupyterlab/services" "^6.2.4"
+    "@lumino/algorithm" "^1.3.3"
+    "@lumino/coreutils" "^1.5.3"
+    "@lumino/disposable" "^1.4.3"
+    "@lumino/messaging" "^1.4.3"
+    "@lumino/properties" "^1.2.3"
+    "@lumino/signaling" "^1.4.3"
+    "@lumino/widgets" "^1.19.0"
+    resize-observer-polyfill "^1.5.1"
+
 "@jupyterlab/rendermime-interfaces@^3.0.0", "@jupyterlab/rendermime-interfaces@^3.0.9", "@jupyterlab/rendermime-interfaces@^3.1.1", "@jupyterlab/rendermime-interfaces@^3.1.6":
   version "3.1.6"
   resolved "https://registry.yarnpkg.com/@jupyterlab/rendermime-interfaces/-/rendermime-interfaces-3.1.6.tgz#61abddfad7b1e0dfc3c502526ee4843e7220e2dc"
@@ -1699,6 +1973,15 @@
   integrity sha512-5xCYoRwZNiz8tyFB6qJQvFWTVy8zLgJFXLIzu2K6jR89mXstzIKYU6BsC8NYUbEx51rxWUuSKCuhT5YoqKgdug==
   dependencies:
     "@jupyterlab/translation" "^3.2.1"
+    "@lumino/coreutils" "^1.5.3"
+    "@lumino/widgets" "^1.19.0"
+
+"@jupyterlab/rendermime-interfaces@^3.2.4":
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/@jupyterlab/rendermime-interfaces/-/rendermime-interfaces-3.2.4.tgz#671e52465fa4e8fba54faafb21642b9dffea45f5"
+  integrity sha512-/zVDeW2ZaRMzQW0EFj5v/hjpJNSDfhJfbx96rprYZC8d0qEvm3Bxyyda4CvsRhmaJKMTAQLW+oOEBn1kNbFTmg==
+  dependencies:
+    "@jupyterlab/translation" "^3.2.4"
     "@lumino/coreutils" "^1.5.3"
     "@lumino/widgets" "^1.19.0"
 
@@ -1723,6 +2006,27 @@
     lodash.escape "^4.0.1"
     marked "^2.0.0"
 
+"@jupyterlab/rendermime@^3.2.4":
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/@jupyterlab/rendermime/-/rendermime-3.2.4.tgz#b3826621eba13b280092e198dd1c896203a1c48d"
+  integrity sha512-G/CS2rMLM+rp5xrQ09Aq2Q2w+c3WN2XvLnEM091ELrfl7WGNytu9ms1bGSaM/ZCXw1o7FDRo1t4Yj066XtkB8A==
+  dependencies:
+    "@jupyterlab/apputils" "^3.2.4"
+    "@jupyterlab/codemirror" "^3.2.4"
+    "@jupyterlab/coreutils" "^5.2.4"
+    "@jupyterlab/nbformat" "^3.2.4"
+    "@jupyterlab/observables" "^4.2.4"
+    "@jupyterlab/rendermime-interfaces" "^3.2.4"
+    "@jupyterlab/services" "^6.2.4"
+    "@jupyterlab/translation" "^3.2.4"
+    "@lumino/algorithm" "^1.3.3"
+    "@lumino/coreutils" "^1.5.3"
+    "@lumino/messaging" "^1.4.3"
+    "@lumino/signaling" "^1.4.3"
+    "@lumino/widgets" "^1.19.0"
+    lodash.escape "^4.0.1"
+    marked "^2.0.0"
+
 "@jupyterlab/services@^6.0.0", "@jupyterlab/services@^6.0.9", "@jupyterlab/services@^6.1.1", "@jupyterlab/services@^6.1.6", "@jupyterlab/services@^6.2.1":
   version "6.2.1"
   resolved "https://registry.yarnpkg.com/@jupyterlab/services/-/services-6.2.1.tgz#e3c16f3257c8dcdb95c154ece8e652017333a69f"
@@ -1733,6 +2037,24 @@
     "@jupyterlab/observables" "^4.2.1"
     "@jupyterlab/settingregistry" "^3.2.1"
     "@jupyterlab/statedb" "^3.2.1"
+    "@lumino/algorithm" "^1.3.3"
+    "@lumino/coreutils" "^1.5.3"
+    "@lumino/disposable" "^1.4.3"
+    "@lumino/polling" "^1.3.3"
+    "@lumino/signaling" "^1.4.3"
+    node-fetch "^2.6.0"
+    ws "^7.4.6"
+
+"@jupyterlab/services@^6.2.4":
+  version "6.2.4"
+  resolved "https://registry.yarnpkg.com/@jupyterlab/services/-/services-6.2.4.tgz#bf6262f9807bbf341d02532736607c9fa085fd58"
+  integrity sha512-WpcKLDkwpq9jUQXUWJJn1cybxwwe8YMC8fdkVnI7RmCg5n0tGSV8+urfUv5Q8DdMdkAJnzSHEC6kIRbGoFpceQ==
+  dependencies:
+    "@jupyterlab/coreutils" "^5.2.4"
+    "@jupyterlab/nbformat" "^3.2.4"
+    "@jupyterlab/observables" "^4.2.4"
+    "@jupyterlab/settingregistry" "^3.2.4"
+    "@jupyterlab/statedb" "^3.2.4"
     "@lumino/algorithm" "^1.3.3"
     "@lumino/coreutils" "^1.5.3"
     "@lumino/disposable" "^1.4.3"
@@ -1767,6 +2089,19 @@
     ajv "^6.12.3"
     json5 "^2.1.1"
 
+"@jupyterlab/settingregistry@^3.2.4":
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/@jupyterlab/settingregistry/-/settingregistry-3.2.4.tgz#6d863891702769769c4840435602206be06e84a6"
+  integrity sha512-kyr6y32YTD4S2XGthy17yRa6BdEQyuXqIl2hIKrn9oPdfM0OF3TDkAByB8W79KLQojsKcmGka19LvQov/N4+6A==
+  dependencies:
+    "@jupyterlab/statedb" "^3.2.4"
+    "@lumino/commands" "^1.12.0"
+    "@lumino/coreutils" "^1.5.3"
+    "@lumino/disposable" "^1.4.3"
+    "@lumino/signaling" "^1.4.3"
+    ajv "^6.12.3"
+    json5 "^2.1.1"
+
 "@jupyterlab/shared-models@^3.2.1":
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/@jupyterlab/shared-models/-/shared-models-3.2.1.tgz#1e6e72506b2266fdf91758234ff335c4146ab334"
@@ -1778,6 +2113,18 @@
     "@lumino/signaling" "^1.4.3"
     y-protocols "^1.0.5"
     yjs "^13.5.6"
+
+"@jupyterlab/shared-models@^3.2.4":
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/@jupyterlab/shared-models/-/shared-models-3.2.4.tgz#979e000985e1cd3d3d6e96c71d010ec6aa61bb26"
+  integrity sha512-Jr2Yz5L0GneKhrFpomm3LW5eGDfRaxWt0c+MT/eFXWmqvVkOKW4N3qPEfP1HNIMqagcC1OoN2pvZAWkE3qQYjA==
+  dependencies:
+    "@jupyterlab/nbformat" "^3.2.4"
+    "@lumino/coreutils" "^1.5.3"
+    "@lumino/disposable" "^1.4.3"
+    "@lumino/signaling" "^1.4.3"
+    y-protocols "^1.0.5"
+    yjs "^13.5.17"
 
 "@jupyterlab/statedb@^3.0.6", "@jupyterlab/statedb@^3.1.1", "@jupyterlab/statedb@^3.1.6":
   version "3.1.6"
@@ -1794,6 +2141,17 @@
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/@jupyterlab/statedb/-/statedb-3.2.1.tgz#c2272beb4286b32b9af73c6d48aa652e345b3702"
   integrity sha512-YkKjY66uTK/7E4oCAigYCFRIqGud55qVMqgdbR13zPStFw/phjrSxpXQd/e9qYSh8M3DnDjoWOT9YjNP88gFpw==
+  dependencies:
+    "@lumino/commands" "^1.12.0"
+    "@lumino/coreutils" "^1.5.3"
+    "@lumino/disposable" "^1.4.3"
+    "@lumino/properties" "^1.2.3"
+    "@lumino/signaling" "^1.4.3"
+
+"@jupyterlab/statedb@^3.2.4":
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/@jupyterlab/statedb/-/statedb-3.2.4.tgz#6581223bf4aac29f2aa8c2fe99e6307c7b88a8a8"
+  integrity sha512-md9AlnrW1pzZTQiVUIJrZgijB3CsSs2J05V5cywo4/sgjwBTO1YGKQDEi6qtMAeO03gxfomGK7xLpoP+2Uaa2A==
   dependencies:
     "@lumino/commands" "^1.12.0"
     "@lumino/coreutils" "^1.5.3"
@@ -1821,21 +2179,41 @@
     react "^17.0.1"
     typestyle "^2.0.4"
 
-"@jupyterlab/testutils@^3.0.11":
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/@jupyterlab/testutils/-/testutils-3.2.1.tgz#f3f491d3e61ddd6c7ae4cf53c53ec743235f7858"
-  integrity sha512-YRQwteVJmH9jiK6NkZgKvg/y7XrzI+NOiapL+vi7pulametF6/g375gARVTakRv3u49PMDMXsxdaQvAaSHD8yQ==
+"@jupyterlab/statusbar@^3.2.4":
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/@jupyterlab/statusbar/-/statusbar-3.2.4.tgz#0d44dcdb354e199c35de5664938dd41a2b276c4f"
+  integrity sha512-1oxNr926SJkxJ0b+hoHEWaFOnv+LVY6MWmv0wQvVzwCVDaQ3IjLXtOYheSXx7WtP4G3NjH2G/wM4mzqMs1JDbQ==
   dependencies:
-    "@jupyterlab/apputils" "^3.2.1"
-    "@jupyterlab/cells" "^3.2.1"
-    "@jupyterlab/codeeditor" "^3.2.1"
-    "@jupyterlab/codemirror" "^3.2.1"
-    "@jupyterlab/coreutils" "^5.2.1"
-    "@jupyterlab/docregistry" "^3.2.1"
-    "@jupyterlab/nbformat" "^3.2.1"
-    "@jupyterlab/notebook" "^3.2.1"
-    "@jupyterlab/rendermime" "^3.2.1"
-    "@jupyterlab/services" "^6.2.1"
+    "@jupyterlab/apputils" "^3.2.4"
+    "@jupyterlab/codeeditor" "^3.2.4"
+    "@jupyterlab/services" "^6.2.4"
+    "@jupyterlab/translation" "^3.2.4"
+    "@jupyterlab/ui-components" "^3.2.4"
+    "@lumino/algorithm" "^1.3.3"
+    "@lumino/coreutils" "^1.5.3"
+    "@lumino/disposable" "^1.4.3"
+    "@lumino/messaging" "^1.4.3"
+    "@lumino/signaling" "^1.4.3"
+    "@lumino/widgets" "^1.19.0"
+    csstype "~3.0.3"
+    react "^17.0.1"
+    typestyle "^2.0.4"
+
+"@jupyterlab/testutils@^3.2.4":
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/@jupyterlab/testutils/-/testutils-3.2.4.tgz#4dba81b4a366b21f5afd8e6077ec1db9c45c1937"
+  integrity sha512-Xkf/pod/PuvNZgzlG8IjYPi5+75PRuh7lu+zw2V/oe5JNyIL2tFJo67eoypVmviOahpr/CbivQnwtDg6eZXbHg==
+  dependencies:
+    "@jupyterlab/apputils" "^3.2.4"
+    "@jupyterlab/cells" "^3.2.4"
+    "@jupyterlab/codeeditor" "^3.2.4"
+    "@jupyterlab/codemirror" "^3.2.4"
+    "@jupyterlab/coreutils" "^5.2.4"
+    "@jupyterlab/docregistry" "^3.2.4"
+    "@jupyterlab/nbformat" "^3.2.4"
+    "@jupyterlab/notebook" "^3.2.4"
+    "@jupyterlab/rendermime" "^3.2.4"
+    "@jupyterlab/services" "^6.2.4"
     "@lumino/algorithm" "^1.3.3"
     "@lumino/coreutils" "^1.5.3"
     "@lumino/properties" "^1.2.3"
@@ -1883,6 +2261,16 @@
     "@jupyterlab/statedb" "^3.2.1"
     "@lumino/coreutils" "^1.5.3"
 
+"@jupyterlab/translation@^3.2.4":
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/@jupyterlab/translation/-/translation-3.2.4.tgz#948c548f304c5d2d18878f2a578c8cee5ea43ef4"
+  integrity sha512-FTXhNw/KRmGGR/stWWyaeyyha3Y7k1jh/dVJIXMO5xlT+zzFHvquGCiMeMZR20P+xBDstrgX8Ei/LhG+gkx0yw==
+  dependencies:
+    "@jupyterlab/coreutils" "^5.2.4"
+    "@jupyterlab/services" "^6.2.4"
+    "@jupyterlab/statedb" "^3.2.4"
+    "@lumino/coreutils" "^1.5.3"
+
 "@jupyterlab/ui-components@^3.0.7":
   version "3.0.7"
   resolved "https://registry.yarnpkg.com/@jupyterlab/ui-components/-/ui-components-3.0.7.tgz#83525d98051e9c74bd415da9e4a0fb20ec6bd609"
@@ -1925,6 +2313,25 @@
     "@blueprintjs/core" "^3.36.0"
     "@blueprintjs/select" "^3.15.0"
     "@jupyterlab/coreutils" "^5.2.1"
+    "@lumino/algorithm" "^1.3.3"
+    "@lumino/commands" "^1.12.0"
+    "@lumino/coreutils" "^1.5.3"
+    "@lumino/disposable" "^1.4.3"
+    "@lumino/signaling" "^1.4.3"
+    "@lumino/virtualdom" "^1.8.0"
+    "@lumino/widgets" "^1.19.0"
+    react "^17.0.1"
+    react-dom "^17.0.1"
+    typestyle "^2.0.4"
+
+"@jupyterlab/ui-components@^3.2.4":
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/@jupyterlab/ui-components/-/ui-components-3.2.4.tgz#ed31720423e6430ab0d63201b1c944cc26f4ff36"
+  integrity sha512-uKxv8U/6TdAMbs0kBm142oAx9R4FcPk+CK5pbsBTInq+nvCmUlSYSAFEnuTbfNLeKQlWHdj8N2Q7upLFgfEs2w==
+  dependencies:
+    "@blueprintjs/core" "^3.36.0"
+    "@blueprintjs/select" "^3.15.0"
+    "@jupyterlab/coreutils" "^5.2.4"
     "@lumino/algorithm" "^1.3.3"
     "@lumino/commands" "^1.12.0"
     "@lumino/coreutils" "^1.5.3"
@@ -6136,6 +6543,13 @@ lib0@^0.2.31, lib0@^0.2.41, lib0@^0.2.42:
   dependencies:
     isomorphic.js "^0.2.4"
 
+lib0@^0.2.43:
+  version "0.2.43"
+  resolved "https://registry.yarnpkg.com/lib0/-/lib0-0.2.43.tgz#1c2ed1fb2e9fe136e92abef7ca56875f2ee66b07"
+  integrity sha512-MJ1KLoz5p3gljIUBfdjjNuL/wlWHHK6+DrcIRhzSRLvtAu1XNdRtRGATYM51KSTI0P2nxJZFQM8rwCH6ga9KUw==
+  dependencies:
+    isomorphic.js "^0.2.4"
+
 lines-and-columns@^1.1.6:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.1.6.tgz#1c00c743b433cd0a4e80758f7b64a57440d9ff00"
@@ -8965,6 +9379,13 @@ y-codemirror@^2.1.1:
   dependencies:
     lib0 "^0.2.41"
 
+y-codemirror@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/y-codemirror/-/y-codemirror-3.0.1.tgz#d8a4e43cf46b5b557e0f03b7bbb65773ff436278"
+  integrity sha512-TsLSoouAZxkxOKbmTj7qdwZNS0lZMVqIdp7/j9EgUUqYj0remZYDGl6VBABrmp9UX1QvX6RoXXqzbNhftgfCbA==
+  dependencies:
+    lib0 "^0.2.42"
+
 y-leveldb@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/y-leveldb/-/y-leveldb-0.1.0.tgz#8b60c1af020252445875ebc70d52666017bcb038"
@@ -9062,6 +9483,13 @@ yauzl@^2.10.0:
   dependencies:
     buffer-crc32 "~0.2.3"
     fd-slicer "~1.1.0"
+
+yjs@^13.5.17:
+  version "13.5.21"
+  resolved "https://registry.yarnpkg.com/yjs/-/yjs-13.5.21.tgz#dd370b011d8e60fb04e65dd2bc4bc89ae94a49f4"
+  integrity sha512-DehXnsAp2ALOgdTUCogQlMNB1lcaP8QE3ovpkE9lcsZpKBn5a/yJI/AXbL3lIN0o0v1ezKk7JmqnfUBiZJSARw==
+  dependencies:
+    lib0 "^0.2.43"
 
 yjs@^13.5.6:
   version "13.5.12"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,7 +2,7 @@
 # yarn lockfile v1
 
 
-"@babel/code-frame@^7.0.0", "@babel/code-frame@^7.16.0":
+"@babel/code-frame@^7.0.0", "@babel/code-frame@^7.12.13", "@babel/code-frame@^7.16.0":
   version "7.16.0"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.16.0.tgz#0dfc80309beec8411e65e706461c408b0bb9b431"
   integrity sha512-IF4EOMEV+bfYwOmNxGzSnjR2EmQod7f1UXOpZM3l4i4o4QNwzjtJAu/HxdjHq0aYBvdqMuQEY1eg0nqW9ZPORA==
@@ -953,37 +953,17 @@
   resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-free/-/fontawesome-free-5.15.4.tgz#ecda5712b61ac852c760d8b3c79c96adca5554e5"
   integrity sha512-eYm8vijH/hpzr/6/1CJ/V/Eb1xQFW2nnUKArb3z+yUWv7HTwj6M7SP957oMjfZjAHU6qpoNc2wQvIxBLWYa/Jg==
 
-"@hapi/address@2.x.x":
-  version "2.1.4"
-  resolved "https://registry.yarnpkg.com/@hapi/address/-/address-2.1.4.tgz#5d67ed43f3fd41a69d4b9ff7b56e7c0d1d0a81e5"
-  integrity sha512-QD1PhQk+s31P1ixsX0H0Suoupp3VMXzIVMSwobR3F3MSUO2YCV0B7xqLcUw/Bh8yuvd3LhpyqLQWTNcRmp6IdQ==
+"@hapi/hoek@^9.0.0":
+  version "9.2.1"
+  resolved "https://registry.yarnpkg.com/@hapi/hoek/-/hoek-9.2.1.tgz#9551142a1980503752536b5050fd99f4a7f13b17"
+  integrity sha512-gfta+H8aziZsm8pZa0vj04KO6biEiisppNgA1kbJvFrrWu9Vm7eaUEy76DIxsuTaWvti5fkJVhllWc6ZTE+Mdw==
 
-"@hapi/bourne@1.x.x":
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/@hapi/bourne/-/bourne-1.3.2.tgz#0a7095adea067243ce3283e1b56b8a8f453b242a"
-  integrity sha512-1dVNHT76Uu5N3eJNTYcvxee+jzX4Z9lfciqRRHCU27ihbUcYi+iSc2iml5Ke1LXe1SyJCLA0+14Jh4tXJgOppA==
-
-"@hapi/hoek@8.x.x", "@hapi/hoek@^8.3.0":
-  version "8.5.1"
-  resolved "https://registry.yarnpkg.com/@hapi/hoek/-/hoek-8.5.1.tgz#fde96064ca446dec8c55a8c2f130957b070c6e06"
-  integrity sha512-yN7kbciD87WzLGc5539Tn0sApjyiGHAJgKvG9W8C7O+6c7qmoQMfVs0W4bX17eqz6C78QJqqFrtgdK5EWf6Qow==
-
-"@hapi/joi@^15.0.3":
-  version "15.1.1"
-  resolved "https://registry.yarnpkg.com/@hapi/joi/-/joi-15.1.1.tgz#c675b8a71296f02833f8d6d243b34c57b8ce19d7"
-  integrity sha512-entf8ZMOK8sc+8YfeOlM8pCfg3b5+WZIKBfUaaJT8UsjAAPjartzxIYm3TIbjvA4u+u++KbcXD38k682nVHDAQ==
+"@hapi/topo@^5.0.0":
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@hapi/topo/-/topo-5.1.0.tgz#dc448e332c6c6e37a4dc02fd84ba8d44b9afb012"
+  integrity sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==
   dependencies:
-    "@hapi/address" "2.x.x"
-    "@hapi/bourne" "1.x.x"
-    "@hapi/hoek" "8.x.x"
-    "@hapi/topo" "3.x.x"
-
-"@hapi/topo@3.x.x":
-  version "3.1.6"
-  resolved "https://registry.yarnpkg.com/@hapi/topo/-/topo-3.1.6.tgz#68d935fa3eae7fdd5ab0d7f953f3205d8b2bfc29"
-  integrity sha512-tAag0jEcjwH+P2quUfipd7liWCNX2F8NvYjQp2wtInsZxnMlypdw0FtAOLxtvvkO+GSRRbmNi8m/5y42PQJYCQ==
-  dependencies:
-    "@hapi/hoek" "^8.3.0"
+    "@hapi/hoek" "^9.0.0"
 
 "@hypnosphi/create-react-context@^0.3.1":
   version "0.3.1"
@@ -1065,6 +1045,16 @@
     "@types/node" "*"
     jest-mock "^26.6.2"
 
+"@jest/environment@^27.3.1":
+  version "27.3.1"
+  resolved "https://registry.yarnpkg.com/@jest/environment/-/environment-27.3.1.tgz#2182defbce8d385fd51c5e7c7050f510bd4c86b1"
+  integrity sha512-BCKCj4mOVLme6Tanoyc9k0ultp3pnmuyHw73UHRPeeZxirsU/7E3HC4le/VDb/SMzE1JcPnto+XBKFOcoiJzVw==
+  dependencies:
+    "@jest/fake-timers" "^27.3.1"
+    "@jest/types" "^27.2.5"
+    "@types/node" "*"
+    jest-mock "^27.3.0"
+
 "@jest/fake-timers@^26.6.2":
   version "26.6.2"
   resolved "https://registry.yarnpkg.com/@jest/fake-timers/-/fake-timers-26.6.2.tgz#459c329bcf70cee4af4d7e3f3e67848123535aad"
@@ -1076,6 +1066,18 @@
     jest-message-util "^26.6.2"
     jest-mock "^26.6.2"
     jest-util "^26.6.2"
+
+"@jest/fake-timers@^27.3.1":
+  version "27.3.1"
+  resolved "https://registry.yarnpkg.com/@jest/fake-timers/-/fake-timers-27.3.1.tgz#1fad860ee9b13034762cdb94266e95609dfce641"
+  integrity sha512-M3ZFgwwlqJtWZ+QkBG5NmC23A9w+A6ZxNsO5nJxJsKYt4yguBd3i8TpjQz5NfCX91nEve1KqD9RA2Q+Q1uWqoA==
+  dependencies:
+    "@jest/types" "^27.2.5"
+    "@sinonjs/fake-timers" "^8.0.1"
+    "@types/node" "*"
+    jest-message-util "^27.3.1"
+    jest-mock "^27.3.0"
+    jest-util "^27.3.1"
 
 "@jest/globals@^26.6.2":
   version "26.6.2"
@@ -1919,6 +1921,23 @@
   resolved "https://registry.yarnpkg.com/@polka/url/-/url-1.0.0-next.21.tgz#5de5a2385a35309427f6011992b544514d559aa1"
   integrity sha512-a5Sab1C4/icpTZVzZc5Ghpz88yQtGOyNqYXcZgOssB2uuAr+wF/MvN6bgtW32q7HHrvBki+BsZ0OuNv6EV3K9g==
 
+"@sideway/address@^4.1.0":
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/@sideway/address/-/address-4.1.2.tgz#811b84333a335739d3969cfc434736268170cad1"
+  integrity sha512-idTz8ibqWFrPU8kMirL0CoPH/A29XOzzAzpyN3zQ4kAWnzmNfFmRaoMNN6VI8ske5M73HZyhIaW4OuSFIdM4oA==
+  dependencies:
+    "@hapi/hoek" "^9.0.0"
+
+"@sideway/formula@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@sideway/formula/-/formula-3.0.0.tgz#fe158aee32e6bd5de85044be615bc08478a0a13c"
+  integrity sha512-vHe7wZ4NOXVfkoRb8T5otiENVlT7a3IAiw7H5M2+GO+9CDgcVUUsX1zalAztCmwyOr2RUTGJdgB+ZvSVqmdHmg==
+
+"@sideway/pinpoint@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@sideway/pinpoint/-/pinpoint-2.0.0.tgz#cff8ffadc372ad29fd3f78277aeb29e632cc70df"
+  integrity sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==
+
 "@sinonjs/commons@^1.7.0":
   version "1.8.3"
   resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.8.3.tgz#3802ddd21a50a949b6721ddd72da36e67e7f1b2d"
@@ -1930,6 +1949,13 @@
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/@sinonjs/fake-timers/-/fake-timers-6.0.1.tgz#293674fccb3262ac782c7aadfdeca86b10c75c40"
   integrity sha512-MZPUxrmFubI36XS1DI3qmI0YdN1gks62JtFZvxR67ljjSNCeK6U08Zx4msEWOXuofgqUt6zPHSi1H9fbjR/NRA==
+  dependencies:
+    "@sinonjs/commons" "^1.7.0"
+
+"@sinonjs/fake-timers@^8.0.1":
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/@sinonjs/fake-timers/-/fake-timers-8.1.0.tgz#3fdc2b6cb58935b21bfb8d1625eb1300484316e7"
+  integrity sha512-OAPJUAtgeINhh/TAlUID4QTs53Njm7xzddaVlEs/SXwgtiD1tW22zAB/W1wdqfrpmikgaWQ9Fw6Ws+hsiRm5Vg==
   dependencies:
     "@sinonjs/commons" "^1.7.0"
 
@@ -2412,6 +2438,11 @@ ansi-styles@^4.0.0, ansi-styles@^4.1.0:
   dependencies:
     color-convert "^2.0.1"
 
+ansi-styles@^5.0.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-5.2.0.tgz#07449690ad45777d1924ac2abb2fc8895dba836b"
+  integrity sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==
+
 anymatch@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-2.0.0.tgz#bcb24b4f37934d9aa7ac17b4adaf89e7c76ef2eb"
@@ -2475,18 +2506,6 @@ asn1.js@^5.2.0:
     minimalistic-assert "^1.0.0"
     safer-buffer "^2.1.0"
 
-asn1@~0.2.3:
-  version "0.2.6"
-  resolved "https://registry.yarnpkg.com/asn1/-/asn1-0.2.6.tgz#0d3a7bb6e64e02a90c0303b31f292868ea09a08d"
-  integrity sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==
-  dependencies:
-    safer-buffer "~2.1.0"
-
-assert-plus@1.0.0, assert-plus@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/assert-plus/-/assert-plus-1.0.0.tgz#f12e0f3c5d77b0b1cdd9146942e4e96c1e4dd525"
-  integrity sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=
-
 assert@^1.1.1:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/assert/-/assert-1.5.0.tgz#55c109aaf6e0aefdb3dc4b71240c70bf574b18eb"
@@ -2537,15 +2556,12 @@ atob@^2.1.2:
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
   integrity sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
 
-aws-sign2@~0.7.0:
-  version "0.7.0"
-  resolved "https://registry.yarnpkg.com/aws-sign2/-/aws-sign2-0.7.0.tgz#b46e890934a9591f2d2f6f86d7e6a9f1b3fe76a8"
-  integrity sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=
-
-aws4@^1.8.0:
-  version "1.11.0"
-  resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.11.0.tgz#d61f46d83b2519250e2784daf5b09479a8b41c59"
-  integrity sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==
+axios@^0.21.1:
+  version "0.21.4"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.4.tgz#c67b90dc0568e5c1cf2b0b858c43ba28e2eda575"
+  integrity sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==
+  dependencies:
+    follow-redirects "^1.14.0"
 
 babel-code-frame@^6.26.0:
   version "6.26.0"
@@ -2762,13 +2778,6 @@ basic-auth@^1.0.3:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/basic-auth/-/basic-auth-1.1.0.tgz#45221ee429f7ee1e5035be3f51533f1cdfd29884"
   integrity sha1-RSIe5Cn37h5QNb4/UVM/HN/SmIQ=
-
-bcrypt-pbkdf@^1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz#a4301d389b6a43f9b67ff3ca11a3f6637e360e9e"
-  integrity sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=
-  dependencies:
-    tweetnacl "^0.14.3"
 
 big.js@^5.2.2:
   version "5.2.2"
@@ -3059,11 +3068,6 @@ capture-exit@^2.0.0:
   dependencies:
     rsvp "^4.8.4"
 
-caseless@~0.12.0:
-  version "0.12.0"
-  resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
-  integrity sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=
-
 chalk@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
@@ -3084,15 +3088,7 @@ chalk@^2.0.0, chalk@^2.4.1, chalk@^2.4.2:
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
-chalk@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-3.0.0.tgz#3f73c2bf526591f574cc492c51e2456349f844e4"
-  integrity sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==
-  dependencies:
-    ansi-styles "^4.1.0"
-    supports-color "^7.1.0"
-
-chalk@^4.0.0, chalk@^4.1.0:
+chalk@^4.0.0, chalk@^4.1.0, chalk@^4.1.1:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
   integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
@@ -3305,7 +3301,7 @@ colors@^1.4.0:
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.4.0.tgz#c50491479d4c1bdaed2c9ced32cf7c7dc2360f78"
   integrity sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==
 
-combined-stream@^1.0.6, combined-stream@^1.0.8, combined-stream@~1.0.6:
+combined-stream@^1.0.8:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
   integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
@@ -3423,7 +3419,7 @@ core-js-compat@^3.18.0, core-js-compat@^3.19.1:
     browserslist "^4.17.6"
     semver "7.0.0"
 
-core-js@^2.4.0, core-js@^2.6.5:
+core-js@^2.4.0:
   version "2.6.12"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.12.tgz#d9333dfa7b065e347cc5682219d6f690859cc2ec"
   integrity sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==
@@ -3432,11 +3428,6 @@ core-js@^3.6.5:
   version "3.19.1"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.19.1.tgz#f6f173cae23e73a7d88fa23b6e9da329276c6641"
   integrity sha512-Tnc7E9iKd/b/ff7GFbhwPVzJzPztGrChB8X8GLqoYGdEOG8IpLnK1xPyo3ZoO3HsK6TodJS58VGPOxA+hLHQMg==
-
-core-util-is@1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
-  integrity sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=
 
 core-util-is@~1.0.0:
   version "1.0.3"
@@ -3581,13 +3572,6 @@ d3-format@^1.3.0:
   version "1.4.5"
   resolved "https://registry.yarnpkg.com/d3-format/-/d3-format-1.4.5.tgz#374f2ba1320e3717eb74a9356c67daee17a7edb4"
   integrity sha512-J0piedu6Z8iB6TbIGfZgDzfXxUFN3qQRMofy2oPdXzQibYGqPB/9iMcxr/TGalU+2RsyDO+U4f33id8tbnSRMQ==
-
-dashdash@^1.12.0:
-  version "1.14.1"
-  resolved "https://registry.yarnpkg.com/dashdash/-/dashdash-1.14.1.tgz#853cfa0f7cbe2fed5de20326b8dd581035f6e2f0"
-  integrity sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=
-  dependencies:
-    assert-plus "^1.0.0"
 
 data-urls@^2.0.0:
   version "2.0.0"
@@ -3810,14 +3794,6 @@ duplexify@^3.4.2, duplexify@^3.6.0:
     inherits "^2.0.1"
     readable-stream "^2.0.0"
     stream-shift "^1.0.0"
-
-ecc-jsbn@~0.1.1:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz#3a83a904e54353287874c564b7549386849a98c9"
-  integrity sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=
-  dependencies:
-    jsbn "~0.1.0"
-    safer-buffer "^2.1.0"
 
 ecstatic@^3.3.2:
   version "3.3.2"
@@ -4083,10 +4059,10 @@ expand-tilde@^1.2.2:
   dependencies:
     os-homedir "^1.0.1"
 
-expect-puppeteer@^4.4.0:
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/expect-puppeteer/-/expect-puppeteer-4.4.0.tgz#1c948af08acdd6c8cbdb7f90e617f44d86888886"
-  integrity sha512-6Ey4Xy2xvmuQu7z7YQtMsaMV0EHJRpVxIDOd5GRrm04/I3nkTKIutELfECsLp6le+b3SSa3cXhPiw6PgqzxYWA==
+expect-puppeteer@^5.0.4:
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/expect-puppeteer/-/expect-puppeteer-5.0.4.tgz#54bfdecabb2acb3e3f0d0292cd3dab2dd8ff5a81"
+  integrity sha512-NV7jSiKhK+byocxg9A+0av+Q2RSCP9bcLVRz7zhHaESeCOkuomMvl9oD+uo1K+NdqRCXhNkQlUGWlmtbrpR1qw==
 
 expect@^26.6.2:
   version "26.6.2"
@@ -4115,11 +4091,6 @@ extend-shallow@^3.0.0, extend-shallow@^3.0.2:
     assign-symbols "^1.0.0"
     is-extendable "^1.0.1"
 
-extend@~3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
-  integrity sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==
-
 extglob@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/extglob/-/extglob-2.0.4.tgz#ad00fe4dc612a9232e8718711dc5cb5ab0285543"
@@ -4144,16 +4115,6 @@ extract-zip@2.0.1:
     yauzl "^2.10.0"
   optionalDependencies:
     "@types/yauzl" "^2.9.1"
-
-extsprintf@1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.3.0.tgz#96918440e3041a7a414f8c52e3c574eb3c3e1e05"
-  integrity sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=
-
-extsprintf@^1.2.0:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.1.tgz#8d172c064867f235c0c84a596806d279bf4bcc07"
-  integrity sha512-Wrk35e8ydCKDj/ArClo1VrPVmN8zph5V4AtHwIuHhvMXsKf73UT3BOD+azBIW+3wOJ4FhEH7zyaJCFvChjYvMA==
 
 fast-deep-equal@^1.0.0:
   version "1.1.0"
@@ -4274,7 +4235,7 @@ find-pkg@^0.1.2:
   dependencies:
     find-file-up "^0.1.2"
 
-find-process@^1.4.3:
+find-process@^1.4.4:
   version "1.4.7"
   resolved "https://registry.yarnpkg.com/find-process/-/find-process-1.4.7.tgz#8c76962259216c381ef1099371465b5b439ea121"
   integrity sha512-/U4CYp1214Xrp3u3Fqr9yNynUrr5Le4y0SsJh2lMDDSbpwYSz3M2SMWQC+wqcx79cN8PQtHQIL8KnuY9M66fdg==
@@ -4306,7 +4267,7 @@ flush-write-stream@^1.0.0:
     inherits "^2.0.3"
     readable-stream "^2.3.6"
 
-follow-redirects@^1.0.0:
+follow-redirects@^1.0.0, follow-redirects@^1.14.0:
   version "1.14.5"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.5.tgz#f09a5848981d3c772b5392309778523f8d85c381"
   integrity sha512-wtphSXy7d4/OR+MvIFbCVBDzZ5520qV8XfPklSN5QtxuMUJZ+b0Wnst1e1lCDocfzuCkHqj8k0FpZqO+UIaKNA==
@@ -4333,11 +4294,6 @@ for-own@^0.1.3:
   dependencies:
     for-in "^1.0.1"
 
-forever-agent@~0.6.1:
-  version "0.6.1"
-  resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
-  integrity sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=
-
 form-data@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-3.0.1.tgz#ebd53791b78356a99af9a300d4282c4d5eb9755f"
@@ -4345,15 +4301,6 @@ form-data@^3.0.0:
   dependencies:
     asynckit "^0.4.0"
     combined-stream "^1.0.8"
-    mime-types "^2.1.12"
-
-form-data@~2.3.2:
-  version "2.3.3"
-  resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.3.3.tgz#dcce52c05f644f298c6a7ab936bd724ceffbf3a6"
-  integrity sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==
-  dependencies:
-    asynckit "^0.4.0"
-    combined-stream "^1.0.6"
     mime-types "^2.1.12"
 
 fragment-cache@^0.2.1:
@@ -4477,13 +4424,6 @@ get-value@^2.0.3, get-value@^2.0.6:
   resolved "https://registry.yarnpkg.com/get-value/-/get-value-2.0.6.tgz#dc15ca1c672387ca76bd37ac0a395ba2042a2c28"
   integrity sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=
 
-getpass@^0.1.1:
-  version "0.1.7"
-  resolved "https://registry.yarnpkg.com/getpass/-/getpass-0.1.7.tgz#5eff8e3e684d569ae4cb2b1282604e8ba62149fa"
-  integrity sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=
-  dependencies:
-    assert-plus "^1.0.0"
-
 glob-parent@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-3.1.0.tgz#9e6af6299d8d3bd2bd40430832bd113df906c5ae"
@@ -4560,19 +4500,6 @@ gzip-size@^6.0.0:
   integrity sha512-ax7ZYomf6jqPTQ4+XCpUGyXKHk5WweS+e05MBO4/y3WJ5RkmPXNKvX+bx1behVILVwr6JSQvZAku021CHPXG3Q==
   dependencies:
     duplexer "^0.1.2"
-
-har-schema@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/har-schema/-/har-schema-2.0.0.tgz#a94c2224ebcac04782a0d9035521f24735b7ec92"
-  integrity sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=
-
-har-validator@~5.1.3:
-  version "5.1.5"
-  resolved "https://registry.yarnpkg.com/har-validator/-/har-validator-5.1.5.tgz#1f0803b9f8cb20c0fa13822df1ecddb36bde1efd"
-  integrity sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==
-  dependencies:
-    ajv "^6.12.3"
-    har-schema "^2.0.0"
 
 harmony-reflect@^1.4.6:
   version "1.6.2"
@@ -4775,15 +4702,6 @@ http-server@^0.12.3:
     portfinder "^1.0.25"
     secure-compare "3.0.1"
     union "~0.5.0"
-
-http-signature@~1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/http-signature/-/http-signature-1.2.0.tgz#9aecd925114772f3d95b65a60abb8f7c18fbace1"
-  integrity sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=
-  dependencies:
-    assert-plus "^1.0.0"
-    jsprim "^1.2.2"
-    sshpk "^1.7.0"
 
 https-browserify@^1.0.0:
   version "1.0.0"
@@ -5104,7 +5022,7 @@ is-stream@^2.0.0:
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-2.0.1.tgz#fac1e3d53b97ad5a9d0ae9cef2389f5810a5c077"
   integrity sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==
 
-is-typedarray@^1.0.0, is-typedarray@~1.0.0:
+is-typedarray@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
   integrity sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=
@@ -5157,11 +5075,6 @@ isomorphic.js@^0.2.4:
   version "0.2.4"
   resolved "https://registry.yarnpkg.com/isomorphic.js/-/isomorphic.js-0.2.4.tgz#24ca374163ae54a7ce3b86ce63b701b91aa84969"
   integrity sha512-Y4NjZceAwaPXctwsHgNsmfuPxR8lJ3f8X7QTAkhltrX4oGIv+eTlgHLXn4tWysC9zGTi929gapnPp+8F8cg7nA==
-
-isstream@~0.1.2:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
-  integrity sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=
 
 istanbul-instrumenter-loader@^3.0.1:
   version "3.0.1"
@@ -5295,18 +5208,18 @@ jest-config@^26.6.3:
     micromatch "^4.0.2"
     pretty-format "^26.6.2"
 
-jest-dev-server@^4.4.0:
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/jest-dev-server/-/jest-dev-server-4.4.0.tgz#557113faae2877452162696aa94c1e44491ab011"
-  integrity sha512-STEHJ3iPSC8HbrQ3TME0ozGX2KT28lbT4XopPxUm2WimsX3fcB3YOptRh12YphQisMhfqNSNTZUmWyT3HEXS2A==
+jest-dev-server@^5.0.3:
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/jest-dev-server/-/jest-dev-server-5.0.3.tgz#324bf6426477450ec3dae349ee9223d43f8be368"
+  integrity sha512-aJR3a5KdY18Lsz+VbREKwx2HM3iukiui+J9rlv9o6iYTwZCSsJazSTStcD9K1q0AIF3oA+FqLOKDyo/sc7+fJw==
   dependencies:
-    chalk "^3.0.0"
+    chalk "^4.1.1"
     cwd "^0.10.0"
-    find-process "^1.4.3"
-    prompts "^2.3.0"
-    spawnd "^4.4.0"
+    find-process "^1.4.4"
+    prompts "^2.4.1"
+    spawnd "^5.0.0"
     tree-kill "^1.2.2"
-    wait-on "^3.3.0"
+    wait-on "^5.3.0"
 
 jest-diff@^26.6.2:
   version "26.6.2"
@@ -5361,15 +5274,28 @@ jest-environment-node@^26.6.2:
     jest-mock "^26.6.2"
     jest-util "^26.6.2"
 
-jest-environment-puppeteer@^4.4.0:
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/jest-environment-puppeteer/-/jest-environment-puppeteer-4.4.0.tgz#d82a37e0e0c51b63cc6b15dea101d53967508860"
-  integrity sha512-iV8S8+6qkdTM6OBR/M9gKywEk8GDSOe05hspCs5D8qKSwtmlUfdtHfB4cakdc68lC6YfK3AUsLirpfgodCHjzQ==
+jest-environment-node@^27.0.1:
+  version "27.3.1"
+  resolved "https://registry.yarnpkg.com/jest-environment-node/-/jest-environment-node-27.3.1.tgz#af7d0eed04edafb740311b303f3fe7c8c27014bb"
+  integrity sha512-T89F/FgkE8waqrTSA7/ydMkcc52uYPgZZ6q8OaZgyiZkJb5QNNCF6oPZjH9IfPFfcc9uBWh1574N0kY0pSvTXw==
   dependencies:
-    chalk "^3.0.0"
+    "@jest/environment" "^27.3.1"
+    "@jest/fake-timers" "^27.3.1"
+    "@jest/types" "^27.2.5"
+    "@types/node" "*"
+    jest-mock "^27.3.0"
+    jest-util "^27.3.1"
+
+jest-environment-puppeteer@^5.0.4:
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/jest-environment-puppeteer/-/jest-environment-puppeteer-5.0.4.tgz#ed64689bf200923828ca98761b4da36eb8ce31bc"
+  integrity sha512-wd4EDOD4QRi11QZ1IV8WsL1wlnnMUtcqtU0BNm+REzRtg78K2XHn3jS6YxGeXIOnsgrJeHxsD7DlRZ/GkFteLg==
+  dependencies:
+    chalk "^4.1.1"
     cwd "^0.10.0"
-    jest-dev-server "^4.4.0"
-    merge-deep "^3.0.2"
+    jest-dev-server "^5.0.3"
+    jest-environment-node "^27.0.1"
+    merge-deep "^3.0.3"
 
 jest-get-type@^26.3.0:
   version "26.3.0"
@@ -5464,6 +5390,21 @@ jest-message-util@^26.6.2:
     slash "^3.0.0"
     stack-utils "^2.0.2"
 
+jest-message-util@^27.3.1:
+  version "27.3.1"
+  resolved "https://registry.yarnpkg.com/jest-message-util/-/jest-message-util-27.3.1.tgz#f7c25688ad3410ab10bcb862bcfe3152345c6436"
+  integrity sha512-bh3JEmxsTZ/9rTm0jQrPElbY2+y48Rw2t47uMfByNyUVR+OfPh4anuyKsGqsNkXk/TI4JbLRZx+7p7Hdt6q1yg==
+  dependencies:
+    "@babel/code-frame" "^7.12.13"
+    "@jest/types" "^27.2.5"
+    "@types/stack-utils" "^2.0.0"
+    chalk "^4.0.0"
+    graceful-fs "^4.2.4"
+    micromatch "^4.0.4"
+    pretty-format "^27.3.1"
+    slash "^3.0.0"
+    stack-utils "^2.0.3"
+
 jest-mock@^26.6.2:
   version "26.6.2"
   resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-26.6.2.tgz#d6cb712b041ed47fe0d9b6fc3474bc6543feb302"
@@ -5472,18 +5413,26 @@ jest-mock@^26.6.2:
     "@jest/types" "^26.6.2"
     "@types/node" "*"
 
+jest-mock@^27.3.0:
+  version "27.3.0"
+  resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-27.3.0.tgz#ddf0ec3cc3e68c8ccd489bef4d1f525571a1b867"
+  integrity sha512-ziZiLk0elZOQjD08bLkegBzv5hCABu/c8Ytx45nJKkysQwGaonvmTxwjLqEA4qGdasq9o2I8/HtdGMNnVsMTGw==
+  dependencies:
+    "@jest/types" "^27.2.5"
+    "@types/node" "*"
+
 jest-pnp-resolver@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz#b704ac0ae028a89108a4d040b3f919dfddc8e33c"
   integrity sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==
 
-jest-puppeteer@^4.4.0:
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/jest-puppeteer/-/jest-puppeteer-4.4.0.tgz#4b906e638a5e3782ed865e7b673c82047b85952e"
-  integrity sha512-ZaiCTlPZ07B9HW0erAWNX6cyzBqbXMM7d2ugai4epBDKpKvRDpItlRQC6XjERoJELKZsPziFGS0OhhUvTvQAXA==
+jest-puppeteer@^5.0.0:
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/jest-puppeteer/-/jest-puppeteer-5.0.4.tgz#c52e3379c11425ce974d025c1a8bf9f599da4b3f"
+  integrity sha512-IUOVKgHEaKsLqahZy/J/DvXB59SQx4AVpZKTRDvJzCdkvdGc3NVsNwUhovr6SK+HOK1TOiqAiXPTAPiIq3mkrg==
   dependencies:
-    expect-puppeteer "^4.4.0"
-    jest-environment-puppeteer "^4.4.0"
+    expect-puppeteer "^5.0.4"
+    jest-environment-puppeteer "^5.0.4"
 
 jest-raw-loader@^1.0.1:
   version "1.0.1"
@@ -5626,7 +5575,7 @@ jest-util@^26.1.0, jest-util@^26.6.2:
     is-ci "^2.0.0"
     micromatch "^4.0.2"
 
-jest-util@^27.0.0:
+jest-util@^27.0.0, jest-util@^27.3.1:
   version "27.3.1"
   resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-27.3.1.tgz#a58cdc7b6c8a560caac9ed6bdfc4e4ff23f80429"
   integrity sha512-8fg+ifEH3GDryLQf/eKZck1DEs2YuVPBCMOaHQxVVLmQwl/CDhWzrvChTX4efLZxGrw+AA0mSXv78cyytBt/uw==
@@ -5681,6 +5630,17 @@ jest@^26.4.2, jest@^26.6.3:
     import-local "^3.0.2"
     jest-cli "^26.6.3"
 
+joi@^17.3.0:
+  version "17.4.2"
+  resolved "https://registry.yarnpkg.com/joi/-/joi-17.4.2.tgz#02f4eb5cf88e515e614830239379dcbbe28ce7f7"
+  integrity sha512-Lm56PP+n0+Z2A2rfRvsfWVDXGEWjXxatPopkQ8qQ5mxCEhwHG+Ettgg5o98FFaxilOxozoa14cFhrE/hOzh/Nw==
+  dependencies:
+    "@hapi/hoek" "^9.0.0"
+    "@hapi/topo" "^5.0.0"
+    "@sideway/address" "^4.1.0"
+    "@sideway/formula" "^3.0.0"
+    "@sideway/pinpoint" "^2.0.0"
+
 jquery-ui-bundle@^1.12.1-migrate:
   version "1.12.1-migrate"
   resolved "https://registry.yarnpkg.com/jquery-ui-bundle/-/jquery-ui-bundle-1.12.1-migrate.tgz#b9343e2c310743527632cff8bedb0c5e9600b14c"
@@ -5715,11 +5675,6 @@ js-yaml@3.14.1, js-yaml@^3.13.1:
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"
-
-jsbn@~0.1.0:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
-  integrity sha1-peZUwuWi3rXyAdls77yoDA7y9RM=
 
 jsdom@^16.4.0:
   version "16.7.0"
@@ -5789,16 +5744,6 @@ json-schema-traverse@^0.4.1:
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz#69f6a87d9513ab8bb8fe63bdb0979c448e684660"
   integrity sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==
 
-json-schema@0.2.3:
-  version "0.2.3"
-  resolved "https://registry.yarnpkg.com/json-schema/-/json-schema-0.2.3.tgz#b480c892e59a2f05954ce727bd3f2a4e882f9e13"
-  integrity sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=
-
-json-stringify-safe@~5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
-  integrity sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=
-
 json-to-html@~0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/json-to-html/-/json-to-html-0.1.2.tgz#7a095ae4a34b33534aad0970ca4b7417b2c11ee3"
@@ -5826,16 +5771,6 @@ jsonfile@^6.0.1:
     universalify "^2.0.0"
   optionalDependencies:
     graceful-fs "^4.1.6"
-
-jsprim@^1.2.2:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/jsprim/-/jsprim-1.4.1.tgz#313e66bc1e5cc06e438bc1b7499c2e5c56acb6a2"
-  integrity sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=
-  dependencies:
-    assert-plus "1.0.0"
-    extsprintf "1.3.0"
-    json-schema "0.2.3"
-    verror "1.10.0"
 
 kind-of@^2.0.1:
   version "2.0.1"
@@ -6174,7 +6109,7 @@ memory-fs@^0.5.0:
     errno "^0.1.3"
     readable-stream "^2.0.1"
 
-merge-deep@^3.0.2:
+merge-deep@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/merge-deep/-/merge-deep-3.0.3.tgz#1a2b2ae926da8b2ae93a0ac15d90cd1922766003"
   integrity sha512-qtmzAS6t6grwEkNrunqTBdn0qKwFgNWvlxUbAV8es9M7Ot1EbyApytCnvE0jALPa46ZpKDUo527kKiaWplmlFA==
@@ -6207,7 +6142,7 @@ micromatch@^3.1.10, micromatch@^3.1.4:
     snapdragon "^0.8.1"
     to-regex "^3.0.2"
 
-micromatch@^4.0.2:
+micromatch@^4.0.2, micromatch@^4.0.4:
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.4.tgz#896d519dfe9db25fce94ceb7a500919bf881ebf9"
   integrity sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==
@@ -6228,7 +6163,7 @@ mime-db@1.51.0:
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.51.0.tgz#d9ff62451859b18342d960850dc3cfb77e63fb0c"
   integrity sha512-5y8A56jg7XVQx2mbv1lu49NR4dokRnhZYTtL+KGfaa27uq4pSTXkwQkFJl4pkRMyNFz/EtYDSkiiEHx3F7UN6g==
 
-mime-types@^2.1.12, mime-types@^2.1.27, mime-types@~2.1.19:
+mime-types@^2.1.12, mime-types@^2.1.27:
   version "2.1.34"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.34.tgz#5a712f9ec1503511a945803640fafe09d3793c24"
   integrity sha512-6cP692WwGIs9XXdOO4++N+7qjqv0rqxxVvJ3VHPh/Sc9mVZcQP+ZGhkKiTvWMQRr2tbHkJP/Yn7Y0npb3ZBs4A==
@@ -6533,11 +6468,6 @@ nwsapi@^2.2.0:
   resolved "https://registry.yarnpkg.com/nwsapi/-/nwsapi-2.2.0.tgz#204879a9e3d068ff2a55139c2c772780681a38b7"
   integrity sha512-h2AatdwYH+JHiZpv7pt/gSX1XoRGb7L/qSIeuqA6GwYoF9w1vP1cw42TO0aI2pNyshRK5893hNSl+1//vHK7hQ==
 
-oauth-sign@~0.9.0:
-  version "0.9.0"
-  resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.9.0.tgz#47a7b016baa68b5fa0ecf3dee08a85c679ac6455"
-  integrity sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==
-
 object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
@@ -6794,11 +6724,6 @@ pend@~1.2.0:
   resolved "https://registry.yarnpkg.com/pend/-/pend-1.2.0.tgz#7a57eb550a6783f9115331fcf4663d5c8e007a50"
   integrity sha1-elfrVQpng/kRUzH89GY9XI4AelA=
 
-performance-now@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
-  integrity sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=
-
 picocolors@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.0.0.tgz#cb5bdc74ff3f51892236eaf79d68bc44564ab81c"
@@ -6924,6 +6849,16 @@ pretty-format@^26.6.2:
     ansi-styles "^4.0.0"
     react-is "^17.0.1"
 
+pretty-format@^27.3.1:
+  version "27.3.1"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-27.3.1.tgz#7e9486365ccdd4a502061fa761d3ab9ca1b78df5"
+  integrity sha512-DR/c+pvFc52nLimLROYjnXPtolawm+uWDxr4FjuLDLUn+ktWnSN851KoHwHzzqq6rfCOjkzN8FLgDrSub6UDuA==
+  dependencies:
+    "@jest/types" "^27.2.5"
+    ansi-regex "^5.0.1"
+    ansi-styles "^5.0.0"
+    react-is "^17.0.1"
+
 private@~0.1.5:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/private/-/private-0.1.8.tgz#2381edb3689f7a53d653190060fcf822d2f368ff"
@@ -6949,7 +6884,7 @@ promise-inflight@^1.0.1:
   resolved "https://registry.yarnpkg.com/promise-inflight/-/promise-inflight-1.0.1.tgz#98472870bf228132fcbdd868129bad12c3c029e3"
   integrity sha1-mEcocL8igTL8vdhoEputEsPAKeM=
 
-prompts@^2.0.1, prompts@^2.3.0:
+prompts@^2.0.1, prompts@^2.4.1:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/prompts/-/prompts-2.4.2.tgz#7b57e73b3a48029ad10ebd44f74b01722a4cb069"
   integrity sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==
@@ -6976,7 +6911,7 @@ prr@~1.0.1:
   resolved "https://registry.yarnpkg.com/prr/-/prr-1.0.1.tgz#d3fc114ba06995a45ec6893f484ceb1d78f5f476"
   integrity sha1-0/wRS6BplaRexok/SEzrHXj19HY=
 
-psl@^1.1.28, psl@^1.1.33:
+psl@^1.1.33:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/psl/-/psl-1.8.0.tgz#9326f8bcfb013adcc005fdff056acce020e51c24"
   integrity sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==
@@ -7057,11 +6992,6 @@ qs@^6.4.0:
   integrity sha512-M528Hph6wsSVOBiYUnGf+K/7w0hNshs/duGsNXPUCLH5XAqjEtiPGwNONLV0tBH8NoGb0mvD5JubnUTrujKDTg==
   dependencies:
     side-channel "^1.0.4"
-
-qs@~6.5.2:
-  version "6.5.2"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
-  integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
 
 querystring-es3@^0.2.0:
   version "0.2.1"
@@ -7318,32 +7248,6 @@ repeating@^2.0.0:
   dependencies:
     is-finite "^1.0.0"
 
-request@^2.88.0:
-  version "2.88.2"
-  resolved "https://registry.yarnpkg.com/request/-/request-2.88.2.tgz#d73c918731cb5a87da047e207234146f664d12b3"
-  integrity sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==
-  dependencies:
-    aws-sign2 "~0.7.0"
-    aws4 "^1.8.0"
-    caseless "~0.12.0"
-    combined-stream "~1.0.6"
-    extend "~3.0.2"
-    forever-agent "~0.6.1"
-    form-data "~2.3.2"
-    har-validator "~5.1.3"
-    http-signature "~1.2.0"
-    is-typedarray "~1.0.0"
-    isstream "~0.1.2"
-    json-stringify-safe "~5.0.1"
-    mime-types "~2.1.19"
-    oauth-sign "~0.9.0"
-    performance-now "^2.1.0"
-    qs "~6.5.2"
-    safe-buffer "^5.1.2"
-    tough-cookie "~2.5.0"
-    tunnel-agent "^0.6.0"
-    uuid "^3.3.2"
-
 require-directory@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
@@ -7436,11 +7340,6 @@ run-queue@^1.0.0, run-queue@^1.0.3:
   dependencies:
     aproba "^1.1.1"
 
-rx@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/rx/-/rx-4.1.0.tgz#a5f13ff79ef3b740fe30aa803fb09f98805d4782"
-  integrity sha1-pfE/957zt0D+MKqAP7CfmIBdR4I=
-
 rxjs@^6.6.3:
   version "6.6.7"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.6.7.tgz#90ac018acabf491bf65044235d5863c4dab804c9"
@@ -7465,7 +7364,7 @@ safe-regex@^1.1.0:
   dependencies:
     ret "~0.1.10"
 
-"safer-buffer@>= 2.1.2 < 3", safer-buffer@^2.0.2, safer-buffer@^2.1.0, safer-buffer@~2.1.0:
+"safer-buffer@>= 2.1.2 < 3", safer-buffer@^2.1.0:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
@@ -7779,15 +7678,15 @@ spawn-command@^0.0.2-1:
   resolved "https://registry.yarnpkg.com/spawn-command/-/spawn-command-0.0.2-1.tgz#62f5e9466981c1b796dc5929937e11c9c6921bd0"
   integrity sha1-YvXpRmmBwbeW3Fkpk34RycaSG9A=
 
-spawnd@^4.4.0:
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/spawnd/-/spawnd-4.4.0.tgz#bb52c5b34a22e3225ae1d3acb873b2cd58af0886"
-  integrity sha512-jLPOfB6QOEgMOQY15Z6+lwZEhH3F5ncXxIaZ7WHPIapwNNLyjrs61okj3VJ3K6tmP5TZ6cO0VAu9rEY4MD4YQg==
+spawnd@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/spawnd/-/spawnd-5.0.0.tgz#ea72200bdc468998e84e1c3e7b914ce85fc1c32c"
+  integrity sha512-28+AJr82moMVWolQvlAIv3JcYDkjkFTEmfDc503wxrF5l2rQ3dFz6DpbXp3kD4zmgGGldfM4xM4v1sFj/ZaIOA==
   dependencies:
     exit "^0.1.2"
-    signal-exit "^3.0.2"
+    signal-exit "^3.0.3"
     tree-kill "^1.2.2"
-    wait-port "^0.2.7"
+    wait-port "^0.2.9"
 
 spdx-correct@^3.0.0:
   version "3.1.1"
@@ -7827,21 +7726,6 @@ sprintf-js@~1.0.2:
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
 
-sshpk@^1.7.0:
-  version "1.16.1"
-  resolved "https://registry.yarnpkg.com/sshpk/-/sshpk-1.16.1.tgz#fb661c0bef29b39db40769ee39fa70093d6f6877"
-  integrity sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==
-  dependencies:
-    asn1 "~0.2.3"
-    assert-plus "^1.0.0"
-    bcrypt-pbkdf "^1.0.0"
-    dashdash "^1.12.0"
-    ecc-jsbn "~0.1.1"
-    getpass "^0.1.1"
-    jsbn "~0.1.0"
-    safer-buffer "^2.0.2"
-    tweetnacl "~0.14.0"
-
 ssri@^6.0.1:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/ssri/-/ssri-6.0.2.tgz#157939134f20464e7301ddba3e90ffa8f7728ac5"
@@ -7849,7 +7733,7 @@ ssri@^6.0.1:
   dependencies:
     figgy-pudding "^3.5.1"
 
-stack-utils@^2.0.2:
+stack-utils@^2.0.2, stack-utils@^2.0.3:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/stack-utils/-/stack-utils-2.0.5.tgz#d25265fca995154659dbbfba3b49254778d2fdd5"
   integrity sha512-xrQcmYhOsn/1kX+Vraq+7j4oE2j/6BFscZ0etmYg81xuM8Gq0022Pxb8+IqgOFUIaxHs0KaSb7T1+OegiNrNFA==
@@ -8191,14 +8075,6 @@ tough-cookie@^4.0.0:
     punycode "^2.1.1"
     universalify "^0.1.2"
 
-tough-cookie@~2.5.0:
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.5.0.tgz#cd9fb2a0aa1d5a12b473bd9fb96fa3dcff65ade2"
-  integrity sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==
-  dependencies:
-    psl "^1.1.28"
-    punycode "^2.1.1"
-
 tr46@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/tr46/-/tr46-2.1.0.tgz#fa87aa81ca5d5941da8cbf1f9b749dc969a4e240"
@@ -8265,18 +8141,6 @@ tty-browserify@0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/tty-browserify/-/tty-browserify-0.0.0.tgz#a157ba402da24e9bf957f9aa69d524eed42901a6"
   integrity sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY=
-
-tunnel-agent@^0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/tunnel-agent/-/tunnel-agent-0.6.0.tgz#27a5dea06b36b04a0a9966774b290868f0fc40fd"
-  integrity sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=
-  dependencies:
-    safe-buffer "^5.0.1"
-
-tweetnacl@^0.14.3, tweetnacl@~0.14.0:
-  version "0.14.5"
-  resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-0.14.5.tgz#5ae68177f192d4456269d108afa93ff8743f4f64"
-  integrity sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=
 
 type-check@~0.3.2:
   version "0.3.2"
@@ -8506,7 +8370,7 @@ util@^0.11.0:
   dependencies:
     inherits "2.0.3"
 
-uuid@^3.3.2, uuid@^3.3.3:
+uuid@^3.3.3:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
@@ -8533,15 +8397,6 @@ validate-npm-package-license@^3.0.1:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
 
-verror@1.10.0:
-  version "1.10.0"
-  resolved "https://registry.yarnpkg.com/verror/-/verror-1.10.0.tgz#3a105ca17053af55d6e270c1f8288682e18da400"
-  integrity sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=
-  dependencies:
-    assert-plus "^1.0.0"
-    core-util-is "1.0.2"
-    extsprintf "^1.2.0"
-
 vm-browserify@^1.0.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/vm-browserify/-/vm-browserify-1.1.2.tgz#78641c488b8e6ca91a75f511e7a3b32a86e5dda0"
@@ -8561,18 +8416,18 @@ w3c-xmlserializer@^2.0.0:
   dependencies:
     xml-name-validator "^3.0.0"
 
-wait-on@^3.3.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/wait-on/-/wait-on-3.3.0.tgz#9940981d047a72a9544a97b8b5fca45b2170a082"
-  integrity sha512-97dEuUapx4+Y12aknWZn7D25kkjMk16PbWoYzpSdA8bYpVfS6hpl2a2pOWZ3c+Tyt3/i4/pglyZctG3J4V1hWQ==
+wait-on@^5.3.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/wait-on/-/wait-on-5.3.0.tgz#584e17d4b3fe7b46ac2b9f8e5e102c005c2776c7"
+  integrity sha512-DwrHrnTK+/0QFaB9a8Ol5Lna3k7WvUR4jzSKmz0YaPBpuN2sACyiPVKVfj6ejnjcajAcvn3wlbTyMIn9AZouOg==
   dependencies:
-    "@hapi/joi" "^15.0.3"
-    core-js "^2.6.5"
-    minimist "^1.2.0"
-    request "^2.88.0"
-    rx "^4.1.0"
+    axios "^0.21.1"
+    joi "^17.3.0"
+    lodash "^4.17.21"
+    minimist "^1.2.5"
+    rxjs "^6.6.3"
 
-wait-port@^0.2.7:
+wait-port@^0.2.9:
   version "0.2.9"
   resolved "https://registry.yarnpkg.com/wait-port/-/wait-port-0.2.9.tgz#3905cf271b5dbe37a85c03b85b418b81cb24ee55"
   integrity sha512-hQ/cVKsNqGZ/UbZB/oakOGFqic00YAMM5/PEj3Bt4vKarv2jWIWzDbqlwT94qMs/exAQAsvMOq99sZblV92zxQ==


### PR DESCRIPTION
Towards #230 

 Summary of Changes
 
  - additional css selectors have been added as `thebe-` one for each instance of `thebelab-` selectors
  - `window.thebelab` is a reference to `window.thebe`
  - code in examples and test files `.spec.js` have been changes to use `thebe` objects/classes exclusively
  - whitespace fixes to some recently touched files
  - Additional Housekeeping was carried out in the activate widget docs
    - updated minimal_example.rst this to use the latest built in controls
    - moved the custom activate button to it's own example file

TODO:
 - [x] document the change and deprecation cycle
 - [x] additional testing
