### PR TITLE
[FIX] Run, Restart and RestartRunAll buttons not appearing

### DIFF
--- a/src/render.js
+++ b/src/render.js
@@ -75,7 +75,7 @@ export function renderCell(element, options) {
 
   let $cm_element = $("<div class='thebelab-input'>");
   $cell.append($cm_element);
-  if (mergedOptions.MountRunButton) {
+  if (mergedOptions.mountRunButton) {
     $cell.append(
       $("<button class='thebelab-button thebelab-run-button'>")
         .text("run")
@@ -83,7 +83,7 @@ export function renderCell(element, options) {
         .click(execute)
     );
   }
-  if (mergedOptions.MountRestartButton) {
+  if (mergedOptions.mountRestartButton) {
     $cell.append(
       $("<button class='thebelab-button thebelab-restart-button'>")
         .text("restart")
@@ -91,7 +91,7 @@ export function renderCell(element, options) {
         .click(restart)
     );
   }
-  if (mergedOptions.MountRestartallButton) {
+  if (mergedOptions.mountRestartallButton) {
     $cell.append(
       $("<button class='thebelab-button thebelab-restartall-button'>")
         .text("restart & run all")


### PR DESCRIPTION
A case issue in code that checks the recently added options to disable the cell buttons, meant that buttons could not be added even when the option was set to true. This has been fixed.

fixes #514 