### PR TITLE
[DOC] code completion

### DIFF
--- a/docs/contribute.md
+++ b/docs/contribute.md
@@ -61,7 +61,7 @@ If you are using `npm` v7 you may encounter **Peer Dependency Errors** see comme
 Using `yarn install` will ensure that you install the latest tested dependencies, and will not make any unintentional local upgrades. `yarn` uses `npm` under the hood, please do not use `npm install` directly to install dependencies.
 ```
 
-#### Peer Dependency Errors
+### Peer Dependency Errors
 
 Due to recent changes in `npm` as of v7 peer dependency issues are flagged as critical errors. However, many projects have not yet resolved these issues in their code base, this means that a project's co-dependencies can prevent installation of a package. This is a know issue, to resolve this there are two options:
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -104,7 +104,7 @@ HTML based examples
 * `Setting predefined output for cells <_static/html_examples/demo-preview.html>`_
 * `Example of a custom launch button, loading from unpgk.com <_static/html_examples/demo-launch-button.html>`_
 
-Source code for these examples can be found in `thebe/docs/_static/html_examples folder.<https://github.com/executablebooks/thebe/tree/master/examples>`_
+Source code for these examples can be found in `thebe/docs/_static/html_examples folder. <https://github.com/executablebooks/thebe/tree/master/examples>`_
 
 .. ATTENTION:: Use the latest release of `thebe` on unpkg
   These examples build a _local_ version of `thebe` in order to show off the latest features.

--- a/docs/ui.rst
+++ b/docs/ui.rst
@@ -13,6 +13,21 @@ Built in UI elements are:
 - Kernel Status Widget
 - Cell Buttons (for every cell): Run, Restart and Restart All
 
+Cell Buttons
+=============
+
+When Thebe is activated, all `<pre>data-executable="true"</pre>` will be converted to code cells and control buttons are rendered by default.
+The buttons are optional, to remove a button, set its respective option to :code:`false`.
+The options are :code:`mountRunButton`, :code:`mountRestartButton`, :code:`mountRestartallButton`.
+
+Keyboard Shortcuts
+==================
+
+The following Keyboard shortcuts are active in code cells:
+
+* `Shift+Enter` - will execute the Cell
+* `Ctrl+Space` - will provide a code completion hint at the cursor
+
 Activate Button
 ===============
 
@@ -40,12 +55,6 @@ Add a :code:`div` element to the page in the desired location.
   <div class="thebe-status" />
 
 Then set the following option to :code:`mountStatusWidget:true` in the Thebe config object
-
-Cell Buttons
-=============
-
-The buttons are optional. By default, all buttons are mounted. To remove a button set its respective option to :code:`false`.
-The options are :code:`mountRunButton`, :code:`mountRestartButton`, :code:`mountRestartallButton`.
 
 Example
 =======


### PR DESCRIPTION
 - Adding a paragraph to explain the keyboard shortcuts now in place for code completion
 - fixed two build warnings due to formatting issues in the docs