### PR TITLE
💿  [DOC] adding jsdoc generated API documentation

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,13 +1,32 @@
 =========
-thebe API
+Thebe API
 =========
 
-The thebe JavaScript API
+When adding Thebe to a page one only needs to know about the bootstrap process and option object.
+By configuring the options you can already manipulate
+
+.. js:autofunction:: thebelab.bootstrap
+
+Configuration Options
+---------------------
+
+.. js:autoclass:: Options
+    :members:
+    :exclude-members: Options
 
 .. note::
 
-    This document is a work in progress.
-    We need to add jsdoc-style docstrings to our exported functions.
+    Above we document the javascript Thebe Options class which provides the default options for Thebe
+    and is a good reference for all current options.
 
+    In typical usage, we add any desired options as an object literal in a script tag on our page,
+    see :doc:`./configure`. for details. Option specified on page will be override the defaults
+    listed above.
 
-.. js:autofunction:: thebe.bootstrap
+High Level JQuery API
+---------------------
+
+.. js:autofunction:: ./render.renderCell
+.. js:autofunction:: ./render.renderAllCells
+.. js:autofunction:: thebelab.mountActivateWidget
+.. js:autofunction:: thebelab.mountStatusWidget

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -5,7 +5,7 @@ Thebe API
 When adding Thebe to a page one only needs to know about the bootstrap process and option object.
 By configuring the options you can already manipulate
 
-.. js:autofunction:: thebelab.bootstrap
+.. js:autofunction:: thebe.bootstrap
 
 Configuration Options
 ---------------------
@@ -28,5 +28,5 @@ High Level JQuery API
 
 .. js:autofunction:: ./render.renderCell
 .. js:autofunction:: ./render.renderAllCells
-.. js:autofunction:: thebelab.mountActivateWidget
-.. js:autofunction:: thebelab.mountStatusWidget
+.. js:autofunction:: thebe.mountActivateWidget
+.. js:autofunction:: thebe.mountStatusWidget

--- a/docs/configure.rst
+++ b/docs/configure.rst
@@ -129,7 +129,7 @@ The below code cell demonstrates this theme:
 
    <button id="activateButton" style="width: 120px; height: 40px; font-size: 1.5em;">Activate</button>
    <script>
-   document.querySelector("#activateButton").addEventListener('click', thebelab.bootstrap)
+   document.querySelector("#activateButton").addEventListener('click', thebe.bootstrap)
    </script>
 
 The above code should be styled according to the

--- a/docs/howto/initialize_cells.rst
+++ b/docs/howto/initialize_cells.rst
@@ -18,7 +18,7 @@ are created when you launch Thebe. By selecting the Thebe button and calling
 the ``click()`` method, the code in that cell will be run (and outputs will show)
 once the Thebe kernel is ready.
 
-Here's a code sample that selects all cells with a tag called ``thebelab-init`` and
+Here's a code sample that selects all cells with a tag called ``thebe-init`` and
 simulates a click on the button.
 
 .. code-block:: javascript

--- a/src/options.js
+++ b/src/options.js
@@ -20,38 +20,205 @@ if (typeof window !== "undefined" && typeof window.define !== "undefined") {
   window.define("@jupyter-widgets/output", output);
 }
 
+/**
+ * Thebe options object
+ */
+export class Options {
+  /**
+   * Option object will be constructed with all defaults
+   */
+  constructor() {
+    /**
+     * When set to ``true`` will bootstrap the library on load
+     * @type {boolean}
+     * @public
+     */
+    this.bootstrap = false;
+
+    /**
+     * Either ``false`` or set to an arbitrary function which is called as part of ``bootstrap``
+     * @type {(function|false)}
+     * @public
+     */
+    this.preRenderHook = false;
+
+    /**
+     * Either false or set to an object with the details of the prompts to strip
+     * @type {(object|false)}
+     * @public
+     * @example
+     * stripPrompts: {
+     *  inPrompt: 'sage: ',
+     *  continuationPrompt: '....: ',
+     *  selector: '.sage-input',
+     * },
+     */
+    this.stripPrompts = false;
+
+    /**
+     * Either false or set to an object with the details of the prompts to strip
+     * @type {(object|false)}
+     * @public
+     * @example
+     * stripOutputPrompts: {
+     *  outPrompt: 'out: ',
+     * },
+     */
+    this.stripOutputPrompts = false;
+
+    /**
+     * Whether to request the kernel immediately when thebe is bootstrapped
+     * instead of on executing code for the first time
+     * @type {boolean}
+     * @public
+     */
+    this.requestKernel = false;
+
+    /**
+     * Whether thebe should look for predefined output of cells before execution
+     *
+     * If this option is enabled and the next div after the cell has the attribute
+     * ``data-output=true`` (default), then the content of this div is rendered as output
+     *
+     * @type {boolean}
+     * @public
+     * */
+    this.predefinedOutput = true;
+
+    /**
+     * When set to ``true`` will attempt to mount a status widget onto any element
+     * with ``class='.thebe-status'`` during bootstrap
+     *
+     * @type {boolean}
+     * @public
+     */
+    this.mountStatusWidget = true;
+
+    /**
+     * When set to ``true`` will attempt to mount an activatebutton onto any element
+     * with ``class='.thebe-activate'`` during bootstrap
+     */
+    this.mountActivateWidget = true;
+
+    /**
+     * Set the URL from which to load mathjax. Set to false to disable mathjax.
+     *
+     * @type {boolean}
+     * @public
+     * @example
+     * // defajult value
+     * mathjaxUrl: "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js"
+     */
+    this.mathjaxUrl =
+      "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js";
+
+    /**
+     * Override the mathjax configuration query string.
+     *
+     * Read more on mathjax configuration here: https://docs.mathjax.org/en/v2.7-latest/configuration.html#loading-and-configuring-mathjax
+     *
+     * @type {boolean}
+     * @public
+     * @example
+     * //default value
+     * mathjaxConfig: "TeX-AMS_CHTML-full,Safe";
+     */
+    this.mathjaxConfig = "TeX-AMS_CHTML-full,Safe";
+
+    /**
+     * CSS Selector for identifying which elements on the page should be made active
+     *
+     * @type {string}
+     * @public
+     * @example
+     * // default value
+     * selector: "[data-executable]"
+     */
+    this.selector = "[data-executable]";
+
+    /**
+     * CSS selector for identifying whether an element should be treated as output
+     *
+     * @type {string}
+     * @public
+     * @example
+     * // default value
+     * outputSelector: "[data-output]"
+     */
+    this.outputSelector = "[data-output]";
+
+    /**
+     * Options for requesting a notebook server from mybinder.org
+     *
+     * @type {(object|false)}
+     * @public
+     * @example
+     * // default value
+     * binderOptions: {
+     *   repo: "minrk/ligo-binder",
+     *   ref: "master",
+     *   binderUrl: "https://mybinder.org",
+     *   savedSession: {
+     *     enabled: true,
+     *     maxAge: 86400,
+     *     storagePrefix: "thebe-binder-",
+     *   },
+     * }
+     */
+    this.binderOptions = {
+      repo: "minrk/ligo-binder",
+      ref: "master",
+      binderUrl: "https://mybinder.org",
+      savedSession: {
+        enabled: true,
+        maxAge: 86400,
+        storagePrefix: "thebe-binder-",
+      },
+    };
+
+    /**
+     * Options for requesting a kernel from the notebook server
+     *
+     * @type {(object|undefined)}
+     * @public
+     * @example
+     * // default value
+     * kernelOptions: {
+     *   path: "/",
+     *   serverSettings: {
+     *     appendToken: true,
+     *   },
+     * };
+     * @example
+     * // python kernel from notebook server on mybinder.org
+     * kernelOptions: {
+     *   name: "python3",
+     *   kernelName: "python3",
+     *   path: "."
+     * },
+     * @example
+     * // python kernel from a local notebook server
+     * kernelOptions: {
+     *   name: "python3",
+     *   kernelName: "python3",
+     *   path: ".",
+     *   serverSettings: {
+     *     "baseUrl": "http://127.0.0.1:8888",
+     *     "token": "test-secret"
+     *   }
+     * },
+     */
+    this.kernelOptions = {
+      path: "/",
+      serverSettings: {
+        appendToken: true,
+      },
+    };
+  }
+}
+
 // options
-const _defaultOptions = {
-  bootstrap: false,
-  preRenderHook: false,
-  stripPrompts: false,
-  requestKernel: false,
-  predefinedOutput: true,
-  mountStatusWidget: true,
-  mountActivateWidget: true,
-  mathjaxUrl: "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js",
-  mathjaxConfig: "TeX-AMS_CHTML-full,Safe",
-  selector: "[data-executable]",
-  outputSelector: "[data-output]",
-  mountRunButton: true,
-  mountRestartButton: true,
-  mountRestartallButton: true,
-  binderOptions: {
-    ref: "master",
-    binderUrl: "https://mybinder.org",
-    savedSession: {
-      enabled: true,
-      maxAge: 86400,
-      storagePrefix: "thebe-binder-",
-    },
-  },
-  kernelOptions: {
-    path: "/",
-    serverSettings: {
-      appendToken: true,
-    },
-  },
-};
+const _defaultOptions = new Options();
 
 let _pageConfigData = undefined;
 

--- a/src/render.js
+++ b/src/render.js
@@ -40,8 +40,25 @@ function getRenderers(options) {
   return _renderers;
 }
 
-// rendering cells
-
+/**
+ * Function to render (initialize) an executable thebe cell.
+ * When called with a jquery element, this function will:
+ *
+ * - Replace that element, with a thebe-cell
+ * - Insert an output element immedately after the call with an attached OutputAreaModel
+ * - Render Run, Run All & Restart buttons
+ * - Attach a CodeMirror Instance
+ * - Return the new element and closed over functions for execution
+ *
+ * @param {Object} element - a jquery element containing the source code for the cell.
+ * Typically this is a ``<pre>`` tag, a tag with ``<div data-executable="true" />`` or any element
+ * decorated in line with the ``options.selector`` option.
+ * @param {Object} options - thebe options to apply
+ * @returns {object} ``reference`` - The cell reference information object
+ * @returns {object} ``reference.cell`` - The jquery element for the cell
+ * @returns {function} ``reference.execute`` - The function to execute the contents of this cell
+ * @returns {function} ``reference.setOutputText`` - A function to render a text stream to the cell OutputArea
+ */
 export function renderCell(element, options) {
   // render a single cell
   // element should be a `<pre>` tag with some code in it
@@ -278,6 +295,15 @@ export function renderCell(element, options) {
   return { cell: $cell, execute, setOutputText };
 }
 
+/**
+ * Find all elements on the page that conform to the css selector provided and
+ * render these as thebe cells.
+ *
+ * @param {Object} options - partial options object
+ * @param {string} options.selector - css selector used to find code cells. By default ``_defaultOptions.selector``
+ * @param {*} kernelPromise unused
+ * @returns {object[]} an array of cell reference objects. See ``renderCell`` return object
+ */
 export function renderAllCells(
   { selector = _defaultOptions.selector } = {},
   kernelPromise

--- a/src/thebe.js
+++ b/src/thebe.js
@@ -44,20 +44,50 @@ export * from "./kernels";
 export * from "./options";
 export * from "./events";
 
+/**
+ * Mount the built-in Status Widget to DOM on a root element expected to
+ * already be on page.
+ *
+ * If the ``mountStatusWidget`` option is ``true`` when ``bootstrap()``
+ * is called the widget will be mounted automatically
+ *
+ * @example
+ * <div class="thebe-status" />
+ * <script>
+ *  thebelab.mountStatusWidget();
+ * </script>
+ *
+ * @returns {undefined}
+ */
 export function mountStatusWidget() {
   thebe.kernelStatus = new KernelStatus(thebe);
   thebe.kernelStatus.mount();
 }
 
+/**
+ * Mount the built-in Activate Button to DOM on a root element expected to
+ * already be on page.
+ *
+ * If the ``mountActivateWidget`` option is ``true`` when ``bootstrap()``
+ * is called the widget will be mounted automatically
+ *
+ * @example
+ * <div class="thebe-activate" />
+ * <script>
+ *  thebelab.mountActivateWidget();
+ * </script>
+ *
+ * @returns {undefined}
+ */
 export function mountActivateWidget() {
   thebe.activateButton = new ActivateWidget(thebe);
   thebe.activateButton.mount();
 }
 
 /**
- * Bootstrap the library based on the configuration given.
+ * Bootstrap the library based on the configuration provided.
  *
- * If bootstrap === true in the configuration and the library is loaded statically
+ * If ``bootstrap === true`` in the configuration and the library is loaded statically
  * then this function will be called automatically on the document load event.
  *
  * @param {Object} options Object containing thebe options.


### PR DESCRIPTION
We have had `jsdoc` in the docs build for a while but with no `jsdocstrings` in the code.

This PR aims to add those for the main elements of the API.

One aspect of this that maybe needs discussion is around the options object and whether we generate documentation using `jsdoc` for that rather than having separate references in the docs and readme that is not coupled with the code. Part of that means changing the options from a javascript literal to a class that `jsdoc` can handle. This is potentially a good step in any case as it allows us to centralise validation and gives us a place to apply a schema, however we need to be careful that the interface for simple usage doesn't change.