### PR TITLE
🛳 exposing any errors during execution in execute return object

### DIFF
--- a/packages/core/src/cell.ts
+++ b/packages/core/src/cell.ts
@@ -130,7 +130,7 @@ class ThebeCell extends PassiveCellRenderer implements IThebeCell {
       console.debug(`thebe:renderer:execute ${this.id}`);
       if (!this.isBusy) this.setAsBusy();
 
-      const useShadow = true;
+      const useShadow = true; // TODO expose as option
       if (useShadow) {
         // Use a shadow output area for the execute request
         const model = new OutputAreaModel({ trusted: true });
@@ -151,7 +151,7 @@ class ThebeCell extends PassiveCellRenderer implements IThebeCell {
         await this.area.future.done;
       }
 
-      let hasExecuteErrors = false;
+      let executeErrors: IError[] | undefined;
       for (let i = 0; i < this.model.length; i++) {
         const out = this.model.get(i);
         if (out.type === 'error') {
@@ -162,7 +162,8 @@ class ThebeCell extends PassiveCellRenderer implements IThebeCell {
               message: errorToMessage(json),
             });
           } else {
-            hasExecuteErrors = true;
+            if (!executeErrors) executeErrors = [json];
+            else executeErrors?.push(json);
             this.events.triggerError({
               status: ErrorStatusEvent.executeError,
               message: errorToMessage(json),
@@ -176,7 +177,7 @@ class ThebeCell extends PassiveCellRenderer implements IThebeCell {
         id: this.id,
         height: this.area.node.offsetHeight,
         width: this.area.node.offsetWidth,
-        error: hasExecuteErrors,
+        error: executeErrors,
       };
     } catch (err: any) {
       console.error('thebe:renderer:execute Error:', err);

--- a/packages/core/src/cell_noexec.ts
+++ b/packages/core/src/cell_noexec.ts
@@ -110,6 +110,6 @@ export default class NonExecutableCell implements IThebeCell {
 
   async execute(source?: string): Promise<IThebeCellExecuteReturn | null> {
     // could potentially allow for markdown rendering here
-    return { id: this.id, height: 0, width: 0, error: false };
+    return { id: this.id, height: 0, width: 0 };
   }
 }

--- a/packages/core/src/notebook.ts
+++ b/packages/core/src/notebook.ts
@@ -10,12 +10,6 @@ import { EventEmitter } from './emitter';
 import type { ICodeCell, INotebookContent, INotebookMetadata } from '@jupyterlab/nbformat';
 import NonExecutableCell from './cell_noexec';
 
-export interface ExecuteReturn {
-  id: string;
-  height: number;
-  width: number;
-}
-
 export interface CodeBlock {
   id: string;
   source: string;
@@ -150,7 +144,7 @@ class ThebeNotebook {
     cellId: string,
     stopOnError = false,
     preprocessor?: (s: string) => string,
-  ): Promise<(ExecuteReturn | null)[]> {
+  ): Promise<(IThebeCellExecuteReturn | null)[]> {
     if (!this.cells) return [];
     this.events.triggerStatus({
       status: NotebookStatusEvent.executing,
@@ -177,7 +171,7 @@ class ThebeNotebook {
   async executeOnly(
     cellId: string,
     preprocessor?: (s: string) => string,
-  ): Promise<ExecuteReturn | null> {
+  ): Promise<IThebeCellExecuteReturn | null> {
     if (!this.cells) return null;
     this.events.triggerStatus({
       status: NotebookStatusEvent.executing,
@@ -196,7 +190,7 @@ class ThebeNotebook {
     cellIds: string[],
     stopOnError = false,
     preprocessor?: (s: string) => string,
-  ): Promise<(ExecuteReturn | null)[]> {
+  ): Promise<(IThebeCellExecuteReturn | null)[]> {
     if (!this.cells) return [];
     this.events.triggerStatus({
       status: NotebookStatusEvent.executing,
@@ -238,7 +232,7 @@ class ThebeNotebook {
   async executeAll(
     stopOnError = false,
     preprocessor?: (s: string) => string,
-  ): Promise<(ExecuteReturn | null)[]> {
+  ): Promise<(IThebeCellExecuteReturn | null)[]> {
     if (!this.cells) return [];
 
     this.events.triggerStatus({

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,6 +1,6 @@
 import type { KernelSpecAPI, ServerConnection, Session } from '@jupyterlab/services';
 import type ThebeSession from './session';
-import type { IOutput } from '@jupyterlab/nbformat';
+import type { IOutput, IError } from '@jupyterlab/nbformat';
 import type { IRenderMimeRegistry } from '@jupyterlab/rendermime';
 import type ThebeServer from './server';
 import type { ServerStatusEvent } from './events';
@@ -104,7 +104,7 @@ export interface IThebeCellExecuteReturn {
   id: string;
   height: number;
   width: number;
-  error: boolean;
+  error?: IError[];
 }
 
 export interface ServerRuntime {


### PR DESCRIPTION
This PR makes it easier to respond to errors from any cell in a notebook. The IError[] is provided so that can calling page can redisplay or process further as needed.