### PR TITLE
🥅 fallback to `kernelName` when `name` not specified

### DIFF
--- a/packages/core/src/options.ts
+++ b/packages/core/src/options.ts
@@ -20,7 +20,7 @@ export function makeBinderOptions(opts: BinderOptions) {
   };
 }
 
-export function makeSavedSessionOptions(opts: SavedSessionOptions) {
+export function makeSavedSessionOptions(opts: SavedSessionOptions): Required<SavedSessionOptions> {
   return {
     enabled: true,
     maxAge: 86400,
@@ -29,20 +29,20 @@ export function makeSavedSessionOptions(opts: SavedSessionOptions) {
   };
 }
 
-export function makeKernelOptions(opts: KernelOptions) {
+export function makeKernelOptions(opts: KernelOptions): Required<KernelOptions> {
   return {
-    path: '/',
-    name: 'python',
-    kernelName: 'python',
-    ...opts,
+    path: opts.path ?? '/',
+    kernelName: opts.kernelName ?? 'python',
+    name: opts.name ?? opts.kernelName ?? 'python',
   };
 }
 
-export function makeServerSettings(settings: ServerSettings) {
+export function makeServerSettings(settings: ServerSettings): Required<ServerSettings> {
   return {
     baseUrl: 'http://localhost:8888',
     token: 'test-secret',
     appendToken: true,
+    wsUrl: 'ws://localhost:8888',
     ...settings,
   };
 }

--- a/packages/core/src/server.ts
+++ b/packages/core/src/server.ts
@@ -87,7 +87,7 @@ class ThebeServer implements ServerRuntime, ServerRestAPI {
 
     // TODO can we defer connection setup, return the session immediately and then have a ready signal?
     const connection = await this.sessionManager?.startNew({
-      name: kernelOptions?.name ?? this.config.kernels.name,
+      name: kernelOptions?.name ?? kernelOptions?.kernelName ?? this.config.kernels.name,
       path: kernelOptions?.path ?? this.config.kernels.path,
       type: 'notebook',
       kernel: {

--- a/packages/core/tests/config.spec.ts
+++ b/packages/core/tests/config.spec.ts
@@ -40,6 +40,7 @@ describe('config', () => {
         baseUrl: 'http://localhost:8888',
         token: 'test-secret',
         appendToken: true,
+        wsUrl: 'ws://localhost:8888',
       });
     });
   });

--- a/packages/core/tests/options.spec.ts
+++ b/packages/core/tests/options.spec.ts
@@ -75,6 +75,18 @@ describe('options', () => {
         kernelName: 'ijpl1',
       });
     });
+    test('overrides - missing name', () => {
+      expect(
+        makeKernelOptions({
+          path: '/notebooks',
+          kernelName: 'ijpl1',
+        }),
+      ).toEqual({
+        path: '/notebooks',
+        name: 'ijpl1',
+        kernelName: 'ijpl1',
+      });
+    });
   });
   describe('server settings', () => {
     test('defaults', () => {
@@ -82,6 +94,7 @@ describe('options', () => {
         baseUrl: 'http://localhost:8888',
         token: 'test-secret',
         appendToken: true,
+        wsUrl: 'ws://localhost:8888',
       });
     });
     test('overrides', () => {
@@ -90,11 +103,13 @@ describe('options', () => {
           baseUrl: 'any-string',
           token: 'any-token-string',
           appendToken: false,
+          wsUrl: 'any-string',
         }),
       ).toEqual({
         baseUrl: 'any-string',
         token: 'any-token-string',
         appendToken: false,
+        wsUrl: 'any-string',
       });
     });
   });


### PR DESCRIPTION
When `name` is not specified in the `CoreOptions`, the value for `kernelName` will be used before falling back to the default value.

* Addresses #595 for the `0.9.x` todo task