### PR TITLE
use latest Jupyterlite with programatic options

### DIFF
--- a/.github/workflows/deploy-demo-preview.yml
+++ b/.github/workflows/deploy-demo-preview.yml
@@ -1,0 +1,30 @@
+name: deploy-demo-preview
+on:
+  pull_request:
+    - opened
+    - reopened
+    - synchronize
+    - closed
+jobs:
+ simple:
+  runs-on: ubuntu-20.04
+    steps:
+      # Action Repo: https://github.com/actions/checkout
+      - name: 'Checkout repo'
+        uses: actions/checkout@v3
+      # Action Repo: https://github.com/actions/cache
+      - name: 'Cache node_modules'
+        uses: actions/cache@v3
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-npm-${{ hashFiles('package-lock.json') }}
+      - name: 'Install'
+        run: npm ci
+      - name: 'Build libs'
+        run: npm run build
+      - name: 'Build demos'
+        run: npm run demo
+      - name: Deploy preview
+        uses: rossjrw/pr-preview-action@v1
+        with:
+          source-dir: ./apps/simple/dist

--- a/.github/workflows/deploy-demo-preview.yml
+++ b/.github/workflows/deploy-demo-preview.yml
@@ -6,13 +6,11 @@ on:
     - synchronize
     - closed
 jobs:
- simple:
-  runs-on: ubuntu-20.04
+  simple:
+    runs-on: ubuntu-20.04
     steps:
-      # Action Repo: https://github.com/actions/checkout
       - name: 'Checkout repo'
         uses: actions/checkout@v3
-      # Action Repo: https://github.com/actions/cache
       - name: 'Cache node_modules'
         uses: actions/cache@v3
         with:

--- a/.github/workflows/deploy-demo-preview.yml
+++ b/.github/workflows/deploy-demo-preview.yml
@@ -1,12 +1,13 @@
 name: deploy-demo-preview
 on:
   pull_request:
-    - opened
-    - reopened
-    - synchronize
-    - closed
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - closed
 jobs:
-  simple:
+  deploy-preview:
     runs-on: ubuntu-20.04
     steps:
       - name: 'Checkout repo'

--- a/apps/simple/static/lite.html
+++ b/apps/simple/static/lite.html
@@ -11,14 +11,28 @@
         useBinder: false
       }
     </script>
-    <script id="jupyter-config-data" type="application/json">
-      {}
-    </script>
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css" crossorigin="anonymous" referrerpolicy="no-referrer" />
+    <!-- <script id="jupyter-config-data" type="application/json">
+      {
+        "litePluginSettings": {
+          "@jupyterlite/pyodide-kernel-extension:kernel": {
+            "pipliteUrls": ["https://unpkg.com/@jupyterlite/pyodide-kernel@0.0.6/pypi/all.json"]
+          }
+        }
+      }
+    </script> -->
+    <link
+      rel="stylesheet"
+      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css"
+      crossorigin="anonymous"
+      referrerpolicy="no-referrer"
+    />
     <link rel="stylesheet" href="thebe.css" />
     <script src="thebe-lite.min.js"></script>
     <link rel="stylesheet" href="main.css" />
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/jupyter-matplotlib@0.11.2/css/mpl_widget.css" />
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/jupyter-matplotlib@0.11.2/css/mpl_widget.css"
+    />
     <script src="index.js"></script>
   </head>
   <body>

--- a/package-lock.json
+++ b/package-lock.json
@@ -4508,6 +4508,64 @@
         "ws": "^7.4.6"
       }
     },
+    "node_modules/@jupyterlab/services/node_modules/@jupyterlab/observables": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/observables/-/observables-4.6.1.tgz",
+      "integrity": "sha512-ez+fxyE3qwQ9grZ0nj2fpgcPIGySs/cNfojfcQatziV2rbFZzrBJJsWFSBhPO55vJd1Mue21aPw1eEK3ok4Wfw==",
+      "dependencies": {
+        "@lumino/algorithm": "^1.9.0",
+        "@lumino/coreutils": "^1.11.0",
+        "@lumino/disposable": "^1.10.0",
+        "@lumino/messaging": "^1.10.0",
+        "@lumino/signaling": "^1.10.0"
+      }
+    },
+    "node_modules/@jupyterlab/services/node_modules/@jupyterlab/settingregistry": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/settingregistry/-/settingregistry-3.6.1.tgz",
+      "integrity": "sha512-zNCYIK6/oWG6JnhmwRGE/Zvn5Xhj0kovcJgTlOSHGyIiHqLfJA9TzHZDNUDANqqxAg4+H9fYdh1+agi4XWGL8A==",
+      "dependencies": {
+        "@jupyterlab/statedb": "^3.6.1",
+        "@lumino/commands": "^1.19.0",
+        "@lumino/coreutils": "^1.11.0",
+        "@lumino/disposable": "^1.10.0",
+        "@lumino/signaling": "^1.10.0",
+        "ajv": "^6.12.3",
+        "json5": "^2.1.1"
+      }
+    },
+    "node_modules/@jupyterlab/services/node_modules/@jupyterlab/statedb": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/statedb/-/statedb-3.6.1.tgz",
+      "integrity": "sha512-6+fGzKUCaWBKX/fZDdXR++WgfvYE+Dv5ma8gkgcHaS2vEup2snkmgZ8fBUJXm5xVpU4KhXjTUb7dafLfG7BL3Q==",
+      "dependencies": {
+        "@lumino/commands": "^1.19.0",
+        "@lumino/coreutils": "^1.11.0",
+        "@lumino/disposable": "^1.10.0",
+        "@lumino/properties": "^1.8.0",
+        "@lumino/signaling": "^1.10.0"
+      }
+    },
+    "node_modules/@jupyterlab/services/node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@jupyterlab/services/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+    },
     "node_modules/@jupyterlab/settingregistry": {
       "version": "3.6.1",
       "resolved": "https://registry.npmjs.org/@jupyterlab/settingregistry/-/settingregistry-3.6.1.tgz",
@@ -6338,11 +6396,14 @@
       "resolved": "https://registry.npmjs.org/@jupyterlab/statedb/-/statedb-3.4.8.tgz",
       "integrity": "sha512-PMlo+x4R8uXPH1BgCJUVVIj/H8SY9scGJU0pqHhYa6mm3R2EHNAwr8JxyqGjAqT3C0VCCCIDzHtQ3f9inW+OXg==",
       "dependencies": {
-        "@lumino/commands": "^1.19.0",
-        "@lumino/coreutils": "^1.11.0",
-        "@lumino/disposable": "^1.10.0",
-        "@lumino/properties": "^1.8.0",
-        "@lumino/signaling": "^1.10.0"
+        "@jupyterlab/coreutils": "~5.5.2",
+        "@jupyterlite/kernel": "^0.1.0-beta.18",
+        "@jupyterlite/licenses": "^0.1.0-beta.18",
+        "@jupyterlite/localforage": "^0.1.0-beta.18",
+        "@jupyterlite/server": "^0.1.0-beta.18",
+        "@jupyterlite/session": "^0.1.0-beta.18",
+        "@jupyterlite/settings": "^0.1.0-beta.18",
+        "@jupyterlite/translation": "^0.1.0-beta.18"
       }
     },
     "node_modules/@jupyterlite/server/node_modules/ajv": {
@@ -6350,14 +6411,11 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
+        "@jupyterlab/coreutils": "~5.5.2",
+        "@jupyterlab/services": "~6.5.2",
+        "@jupyterlite/kernel": "^0.1.0-beta.18",
+        "@lumino/algorithm": "^1.9.1",
+        "@lumino/coreutils": "^1.12.0"
       }
     },
     "node_modules/@jupyterlite/server/node_modules/json-schema-traverse": {
@@ -36988,6 +37046,62 @@
         "@lumino/signaling": "^1.10.0",
         "node-fetch": "^2.6.0",
         "ws": "^7.4.6"
+      },
+      "dependencies": {
+        "@jupyterlab/observables": {
+          "version": "4.6.1",
+          "resolved": "https://registry.npmjs.org/@jupyterlab/observables/-/observables-4.6.1.tgz",
+          "integrity": "sha512-ez+fxyE3qwQ9grZ0nj2fpgcPIGySs/cNfojfcQatziV2rbFZzrBJJsWFSBhPO55vJd1Mue21aPw1eEK3ok4Wfw==",
+          "requires": {
+            "@lumino/algorithm": "^1.9.0",
+            "@lumino/coreutils": "^1.11.0",
+            "@lumino/disposable": "^1.10.0",
+            "@lumino/messaging": "^1.10.0",
+            "@lumino/signaling": "^1.10.0"
+          }
+        },
+        "@jupyterlab/settingregistry": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@jupyterlab/settingregistry/-/settingregistry-3.6.1.tgz",
+          "integrity": "sha512-zNCYIK6/oWG6JnhmwRGE/Zvn5Xhj0kovcJgTlOSHGyIiHqLfJA9TzHZDNUDANqqxAg4+H9fYdh1+agi4XWGL8A==",
+          "requires": {
+            "@jupyterlab/statedb": "^3.6.1",
+            "@lumino/commands": "^1.19.0",
+            "@lumino/coreutils": "^1.11.0",
+            "@lumino/disposable": "^1.10.0",
+            "@lumino/signaling": "^1.10.0",
+            "ajv": "^6.12.3",
+            "json5": "^2.1.1"
+          }
+        },
+        "@jupyterlab/statedb": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@jupyterlab/statedb/-/statedb-3.6.1.tgz",
+          "integrity": "sha512-6+fGzKUCaWBKX/fZDdXR++WgfvYE+Dv5ma8gkgcHaS2vEup2snkmgZ8fBUJXm5xVpU4KhXjTUb7dafLfG7BL3Q==",
+          "requires": {
+            "@lumino/commands": "^1.19.0",
+            "@lumino/coreutils": "^1.11.0",
+            "@lumino/disposable": "^1.10.0",
+            "@lumino/properties": "^1.8.0",
+            "@lumino/signaling": "^1.10.0"
+          }
+        },
+        "ajv": {
+          "version": "6.12.6",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+          "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "json-schema-traverse": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+        }
       }
     },
     "@jupyterlab/settingregistry": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4143,9 +4143,9 @@
       }
     },
     "node_modules/@jupyterlab/coreutils": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/coreutils/-/coreutils-5.6.1.tgz",
-      "integrity": "sha512-nS4ixC9H53lFzdszOfZfDhlM2hlXfOtQAn6TnA/0Ra/gTBQ+LEbFIWdAp588iKuv8eKX39O/Us53T4oq24A31g==",
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/coreutils/-/coreutils-5.6.3.tgz",
+      "integrity": "sha512-jRVTpwGzP9wBNYuaZTip89FS1qbeSYrEO2qdNVdW2rs0mQHcIlu3Fkv5muMFmKYGi0XHhG3UhZiWQ7qiPw2svQ==",
       "dependencies": {
         "@lumino/coreutils": "^1.11.0",
         "@lumino/disposable": "^1.10.0",
@@ -6080,13 +6080,13 @@
       }
     },
     "node_modules/@jupyterlite/contents": {
-      "version": "0.1.0-beta.18",
-      "resolved": "https://registry.npmjs.org/@jupyterlite/contents/-/contents-0.1.0-beta.18.tgz",
-      "integrity": "sha512-O6iOFD8MwfB3xOa2De1JtIIbdn63dXio40g2XnQlLbH3hPgUeTE2p1Vl9VjTQmULH/e3SjtJAjFpKYgTfkMr0g==",
+      "version": "0.1.0-rc.0",
+      "resolved": "https://registry.npmjs.org/@jupyterlite/contents/-/contents-0.1.0-rc.0.tgz",
+      "integrity": "sha512-B/TZboRyIW+/+4L4Ult6oBLu1netzNDO2QTWNJXEZYnYll2tH27KKh5puV+hbihGvZzNBmqGNIJiaPKYQghPag==",
       "dependencies": {
-        "@jupyterlab/nbformat": "~3.5.2",
-        "@jupyterlab/services": "~6.5.2",
-        "@jupyterlite/localforage": "^0.1.0-beta.18",
+        "@jupyterlab/nbformat": "~3.5.3",
+        "@jupyterlab/services": "~6.5.3",
+        "@jupyterlite/localforage": "^0.1.0-rc.0",
         "@lumino/coreutils": "^1.12.0",
         "@types/emscripten": "^1.39.6",
         "localforage": "^1.9.0",
@@ -6132,13 +6132,13 @@
       }
     },
     "node_modules/@jupyterlite/kernel": {
-      "version": "0.1.0-beta.18",
-      "resolved": "https://registry.npmjs.org/@jupyterlite/kernel/-/kernel-0.1.0-beta.18.tgz",
-      "integrity": "sha512-GHZMBee085Z1BYyBIm3tJt2Le1K3WCFZRihG/99Xj0l3gaY8SGGvvUHuMNirFwyjmghXYdfckYafEcZouIAjnQ==",
+      "version": "0.1.0-rc.0",
+      "resolved": "https://registry.npmjs.org/@jupyterlite/kernel/-/kernel-0.1.0-rc.0.tgz",
+      "integrity": "sha512-j7Cc4tZQzpbTlbw+TLSKpfADDV1gNFuwt8wSUkik87w3V2WkgmQaeVvqNQc20qkAqjoJJasdqpx9I/n7kiNzUw==",
       "dependencies": {
-        "@jupyterlab/coreutils": "~5.5.2",
-        "@jupyterlab/observables": "~4.5.2",
-        "@jupyterlab/services": "~6.5.2",
+        "@jupyterlab/coreutils": "~5.5.3",
+        "@jupyterlab/observables": "~4.5.3",
+        "@jupyterlab/services": "~6.5.3",
         "@lumino/coreutils": "^1.12.0",
         "@lumino/disposable": "^1.10.1",
         "@lumino/signaling": "^1.10.1",
@@ -6193,11 +6193,11 @@
       }
     },
     "node_modules/@jupyterlite/licenses": {
-      "version": "0.1.0-beta.18",
-      "resolved": "https://registry.npmjs.org/@jupyterlite/licenses/-/licenses-0.1.0-beta.18.tgz",
-      "integrity": "sha512-OnrAR2LP5ryam/v7jDoarxMv4VbEpoz4Ll8ccU+emCCI4iCrpWwEoDAxFCMl9cFVuzPiTYy0z6nIk18kkf3flw==",
+      "version": "0.1.0-rc.0",
+      "resolved": "https://registry.npmjs.org/@jupyterlite/licenses/-/licenses-0.1.0-rc.0.tgz",
+      "integrity": "sha512-3j1u029+e0HUgnsc7CwTME0BDJu5Xoqlq5x1xOS1ZeLrDEY3zSwo6HufI9pEHb1Flj4pX2bIBybimThEfwtj7Q==",
       "dependencies": {
-        "@jupyterlab/coreutils": "~5.5.2"
+        "@jupyterlab/coreutils": "~5.5.3"
       }
     },
     "node_modules/@jupyterlite/licenses/node_modules/@jupyterlab/coreutils": {
@@ -6215,11 +6215,11 @@
       }
     },
     "node_modules/@jupyterlite/localforage": {
-      "version": "0.1.0-beta.18",
-      "resolved": "https://registry.npmjs.org/@jupyterlite/localforage/-/localforage-0.1.0-beta.18.tgz",
-      "integrity": "sha512-ukPXjs+thOG86IPoZmHQOBfNj1WfS4BgpRX1els6zL0yWITkpsLAju0LTF9A5Hsu0VdrtNq5KPvhmGShsZmJ7Q==",
+      "version": "0.1.0-rc.0",
+      "resolved": "https://registry.npmjs.org/@jupyterlite/localforage/-/localforage-0.1.0-rc.0.tgz",
+      "integrity": "sha512-aMsg8xta8ptzBGA/kfMHzuUzQPsP7Gt1vXS7TwtCTewUfbr0E5S4vjsGEvwdz/0ELtqundkeaOY5BnCt7osXgQ==",
       "dependencies": {
-        "@jupyterlab/coreutils": "~5.5.2",
+        "@jupyterlab/coreutils": "~5.5.3",
         "@lumino/coreutils": "^1.5.3",
         "localforage": "^1.9.0",
         "localforage-memoryStorageDriver": "^0.9.2"
@@ -6239,81 +6239,68 @@
         "url-parse": "~1.5.1"
       }
     },
-    "node_modules/@jupyterlite/pyolite-kernel": {
-      "version": "0.1.0-beta.18",
-      "resolved": "https://registry.npmjs.org/@jupyterlite/pyolite-kernel/-/pyolite-kernel-0.1.0-beta.18.tgz",
-      "integrity": "sha512-CsUugrlRoD+naCbOYEuhLecL9YgwH6r5TDeVfBHtlBzzP2MR+KPnwHSXbx7WiDVwzRVcG0pFrzGvRs0CQ0Rvrw==",
+    "node_modules/@jupyterlite/pyodide-kernel": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@jupyterlite/pyodide-kernel/-/pyodide-kernel-0.0.6.tgz",
+      "integrity": "sha512-zXKSNWOhTQQXn4vCpZTDNBHcwCwKqPYAxQ4P4jNCMbtkCjFAauO2biAODbFdKseS/k1fP2Xy0MBGlmLK115tgA==",
       "dependencies": {
         "@jupyterlite/contents": "^0.1.0-beta.18",
         "@jupyterlite/kernel": "^0.1.0-beta.18",
         "comlink": "^4.3.1"
       }
     },
-    "node_modules/@jupyterlite/pyolite-kernel-extension": {
-      "version": "0.1.0-beta.14",
-      "resolved": "https://registry.npmjs.org/@jupyterlite/pyolite-kernel-extension/-/pyolite-kernel-extension-0.1.0-beta.14.tgz",
-      "integrity": "sha512-OmE9ceijWg4bKbw0uLoH89ES6N0LyYEoK8vNBfOuXM6+gF1uUgQfoO6BGHK0Rle0I1t1N5EV0tcZcZ3MqOZvDQ==",
+    "node_modules/@jupyterlite/pyodide-kernel-extension": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@jupyterlite/pyodide-kernel-extension/-/pyodide-kernel-extension-0.0.6.tgz",
+      "integrity": "sha512-kQX0dOESiLWfQ3eAzprTV5vTN7tbrI86AvzEtDCUchplfvwvyh21DueQ275TrO7/NoQAZ2A6GCrS3vJLHgRPpQ==",
       "dependencies": {
-        "@jupyterlab/coreutils": "~5.4.6",
-        "@jupyterlite/kernel": "^0.1.0-beta.14",
-        "@jupyterlite/pyolite-kernel": "^0.1.0-beta.14",
-        "@jupyterlite/server": "^0.1.0-beta.14"
-      }
-    },
-    "node_modules/@jupyterlite/pyolite-kernel-extension/node_modules/@jupyterlab/coreutils": {
-      "version": "5.4.8",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/coreutils/-/coreutils-5.4.8.tgz",
-      "integrity": "sha512-UICv9nBCL+thSSOFlLWGjPm+UTT1ioPq+pOMjgn0E/DPliUMAMKtrAU5viAbRhITGAU55uL2KH9ijMUIc6o3xA==",
-      "dependencies": {
-        "@lumino/coreutils": "^1.11.0",
-        "@lumino/disposable": "^1.10.0",
-        "@lumino/signaling": "^1.10.0",
-        "minimist": "~1.2.0",
-        "moment": "^2.24.0",
-        "path-browserify": "^1.0.0",
-        "url-parse": "~1.5.1"
+        "@jupyterlab/coreutils": "^5.5.2",
+        "@jupyterlite/contents": "^0.1.0-beta.18",
+        "@jupyterlite/kernel": "^0.1.0-beta.18",
+        "@jupyterlite/pyodide-kernel": "^0.0.6",
+        "@jupyterlite/server": "^0.1.0-beta.18"
       }
     },
     "node_modules/@jupyterlite/server": {
-      "version": "0.1.0-beta.14",
-      "resolved": "https://registry.npmjs.org/@jupyterlite/server/-/server-0.1.0-beta.14.tgz",
-      "integrity": "sha512-fMW6+jrbbo5XuCaQ79cnZhQEj6kY6bwUtjrOluG5YTrm3IWfEtIZvxwQAbq3GeEiYIih02TftFmUJajRII3q+g==",
+      "version": "0.1.0-rc.0",
+      "resolved": "https://registry.npmjs.org/@jupyterlite/server/-/server-0.1.0-rc.0.tgz",
+      "integrity": "sha512-pKmxbAtEM0JQW9zjrAkwd3L7dpnhPT0XXsCuBorJK7YMvTFmmi/xHQa+Zcif+9DViay51AALR5bFXkc6GTQDxw==",
       "dependencies": {
-        "@jupyterlab/coreutils": "~5.4.6",
-        "@jupyterlab/nbformat": "~3.4.8",
-        "@jupyterlab/observables": "~4.4.4",
-        "@jupyterlab/services": "~6.4.6",
-        "@jupyterlab/settingregistry": "~3.4.8",
-        "@jupyterlab/statedb": "~3.4.8",
-        "@jupyterlite/contents": "^0.1.0-beta.14",
-        "@jupyterlite/kernel": "^0.1.0-beta.14",
-        "@jupyterlite/session": "^0.1.0-beta.14",
-        "@jupyterlite/settings": "^0.1.0-beta.14",
-        "@jupyterlite/translation": "^0.1.0-beta.14",
+        "@jupyterlab/coreutils": "~5.5.3",
+        "@jupyterlab/nbformat": "~3.5.3",
+        "@jupyterlab/observables": "~4.5.3",
+        "@jupyterlab/services": "~6.5.3",
+        "@jupyterlab/settingregistry": "~3.5.3",
+        "@jupyterlab/statedb": "~3.5.3",
+        "@jupyterlite/contents": "^0.1.0-rc.0",
+        "@jupyterlite/kernel": "^0.1.0-rc.0",
+        "@jupyterlite/session": "^0.1.0-rc.0",
+        "@jupyterlite/settings": "^0.1.0-rc.0",
+        "@jupyterlite/translation": "^0.1.0-rc.0",
         "@lumino/application": "^1.27.0",
         "@lumino/coreutils": "^1.12.0",
         "mock-socket": "^9.1.0"
       }
     },
     "node_modules/@jupyterlite/server-extension": {
-      "version": "0.1.0-beta.14",
-      "resolved": "https://registry.npmjs.org/@jupyterlite/server-extension/-/server-extension-0.1.0-beta.14.tgz",
-      "integrity": "sha512-cs0V1wzIy5ZOrn3RUtOltrlaAthAiNf1XNfvu4klpjoZeBoIYOPo0x8xrmNonEVq8AkVw8TZrR9RLZws4p41HQ==",
+      "version": "0.1.0-rc.0",
+      "resolved": "https://registry.npmjs.org/@jupyterlite/server-extension/-/server-extension-0.1.0-rc.0.tgz",
+      "integrity": "sha512-N2BTHRiV6sxpc6QO+5gk5zfxotZqvOoTNbxc180GhnRXJv1RUuCQePCLDIwpbqsGbjt91yvnai2KhZofayWZKA==",
       "dependencies": {
-        "@jupyterlab/coreutils": "~5.4.6",
-        "@jupyterlite/kernel": "^0.1.0-beta.14",
-        "@jupyterlite/licenses": "^0.1.0-beta.14",
-        "@jupyterlite/localforage": "^0.1.0-beta.14",
-        "@jupyterlite/server": "^0.1.0-beta.14",
-        "@jupyterlite/session": "^0.1.0-beta.14",
-        "@jupyterlite/settings": "^0.1.0-beta.14",
-        "@jupyterlite/translation": "^0.1.0-beta.14"
+        "@jupyterlab/coreutils": "~5.5.3",
+        "@jupyterlite/kernel": "^0.1.0-rc.0",
+        "@jupyterlite/licenses": "^0.1.0-rc.0",
+        "@jupyterlite/localforage": "^0.1.0-rc.0",
+        "@jupyterlite/server": "^0.1.0-rc.0",
+        "@jupyterlite/session": "^0.1.0-rc.0",
+        "@jupyterlite/settings": "^0.1.0-rc.0",
+        "@jupyterlite/translation": "^0.1.0-rc.0"
       }
     },
     "node_modules/@jupyterlite/server-extension/node_modules/@jupyterlab/coreutils": {
-      "version": "5.4.8",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/coreutils/-/coreutils-5.4.8.tgz",
-      "integrity": "sha512-UICv9nBCL+thSSOFlLWGjPm+UTT1ioPq+pOMjgn0E/DPliUMAMKtrAU5viAbRhITGAU55uL2KH9ijMUIc6o3xA==",
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/coreutils/-/coreutils-5.5.3.tgz",
+      "integrity": "sha512-GCAymoQAwscE8MGH7eb366bRxvWawOXKFeyq642SAtl0/xWty8Kem56UfdUdyTCRzxwYW5r1sJuRHBvbTjnvUA==",
       "dependencies": {
         "@lumino/coreutils": "^1.11.0",
         "@lumino/disposable": "^1.10.0",
@@ -6325,9 +6312,9 @@
       }
     },
     "node_modules/@jupyterlite/server/node_modules/@jupyterlab/coreutils": {
-      "version": "5.4.8",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/coreutils/-/coreutils-5.4.8.tgz",
-      "integrity": "sha512-UICv9nBCL+thSSOFlLWGjPm+UTT1ioPq+pOMjgn0E/DPliUMAMKtrAU5viAbRhITGAU55uL2KH9ijMUIc6o3xA==",
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/coreutils/-/coreutils-5.5.3.tgz",
+      "integrity": "sha512-GCAymoQAwscE8MGH7eb366bRxvWawOXKFeyq642SAtl0/xWty8Kem56UfdUdyTCRzxwYW5r1sJuRHBvbTjnvUA==",
       "dependencies": {
         "@lumino/coreutils": "^1.11.0",
         "@lumino/disposable": "^1.10.0",
@@ -6339,17 +6326,17 @@
       }
     },
     "node_modules/@jupyterlite/server/node_modules/@jupyterlab/nbformat": {
-      "version": "3.4.8",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/nbformat/-/nbformat-3.4.8.tgz",
-      "integrity": "sha512-RcyITAagwXMIWqehpctb43mVB1H3LrTfikGvykLICmA5AfT+byhooCDN4d+ipg4rkeioUmEgX+2uTfForCsJWQ==",
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/nbformat/-/nbformat-3.5.3.tgz",
+      "integrity": "sha512-7HIdRXrm5BKrP4P1cT+b34BFiqmEcr5fJyyBW6nIm3DXh9ZNTKhQUN8vGvkL7qTXZFXmdhc//eTSZUPQ3F3JcA==",
       "dependencies": {
         "@lumino/coreutils": "^1.11.0"
       }
     },
     "node_modules/@jupyterlite/server/node_modules/@jupyterlab/observables": {
-      "version": "4.4.8",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/observables/-/observables-4.4.8.tgz",
-      "integrity": "sha512-TT7YQNxvLnfuzbHQjoovfVN02dXDG/zxfWiA1RkycAJnQ/aTgRtEMlLMs7dUqNCh6ej6zNQOUEduJInro/OL4A==",
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/observables/-/observables-4.5.3.tgz",
+      "integrity": "sha512-WERivf/gr2ZMGCXEiJpgv4AGVG8ovKzdg/tIgzrf72eB4Jq5WXMy4r5GLvM+g3PkiiG8o50C2t/SXcUlvNDTaw==",
       "dependencies": {
         "@lumino/algorithm": "^1.9.0",
         "@lumino/coreutils": "^1.11.0",
@@ -6359,15 +6346,15 @@
       }
     },
     "node_modules/@jupyterlite/server/node_modules/@jupyterlab/services": {
-      "version": "6.4.8",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/services/-/services-6.4.8.tgz",
-      "integrity": "sha512-/acj4d1A1V9KDN+k4CUokOA8e/IxaoJW2B+FJxVnTZvVOBh7093EIG+HYL1SQuQ8CUc2T4DNiq9mG3skiSe2fQ==",
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/services/-/services-6.5.3.tgz",
+      "integrity": "sha512-9wIVzKeAvgx9J0g9DoG96yauG+HU4/ms28DM+7iS34/akoHSM17czWGGnmKY0Y3MyZ22up7aZelCthP+WiAQxQ==",
       "dependencies": {
-        "@jupyterlab/coreutils": "^5.4.8",
-        "@jupyterlab/nbformat": "^3.4.8",
-        "@jupyterlab/observables": "^4.4.8",
-        "@jupyterlab/settingregistry": "^3.4.8",
-        "@jupyterlab/statedb": "^3.4.8",
+        "@jupyterlab/coreutils": "^5.5.3",
+        "@jupyterlab/nbformat": "^3.5.3",
+        "@jupyterlab/observables": "^4.5.3",
+        "@jupyterlab/settingregistry": "^3.5.3",
+        "@jupyterlab/statedb": "^3.5.3",
         "@lumino/algorithm": "^1.9.0",
         "@lumino/coreutils": "^1.11.0",
         "@lumino/disposable": "^1.10.0",
@@ -6378,11 +6365,11 @@
       }
     },
     "node_modules/@jupyterlite/server/node_modules/@jupyterlab/settingregistry": {
-      "version": "3.4.8",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/settingregistry/-/settingregistry-3.4.8.tgz",
-      "integrity": "sha512-w9MNFivKXUOLrEvWckpcYm3XAZr0sbcKQ33SkftaLSQODsFlUwkcsjCPJJATVyxiWXAsCAgUlOKdNcqWxYXvOA==",
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/settingregistry/-/settingregistry-3.5.3.tgz",
+      "integrity": "sha512-PWkISgGHikSaOEOiPVIDCcnLdiuXAcFdI7ZPLWoaq0v+NykemenQ5+MXOEaEOgf3KUAE8PFAGNr+3indbwFXNw==",
       "dependencies": {
-        "@jupyterlab/statedb": "^3.4.8",
+        "@jupyterlab/statedb": "^3.5.3",
         "@lumino/commands": "^1.19.0",
         "@lumino/coreutils": "^1.11.0",
         "@lumino/disposable": "^1.10.0",
@@ -6392,18 +6379,15 @@
       }
     },
     "node_modules/@jupyterlite/server/node_modules/@jupyterlab/statedb": {
-      "version": "3.4.8",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/statedb/-/statedb-3.4.8.tgz",
-      "integrity": "sha512-PMlo+x4R8uXPH1BgCJUVVIj/H8SY9scGJU0pqHhYa6mm3R2EHNAwr8JxyqGjAqT3C0VCCCIDzHtQ3f9inW+OXg==",
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/statedb/-/statedb-3.5.3.tgz",
+      "integrity": "sha512-QlFLcSzOJUjjwiXjgv5dQVHTRXXBT5+e/kJKVLddi80li/p0hBmKQHP+9e15Ql+i599uyoE6zE7lyMRPHrO98w==",
       "dependencies": {
-        "@jupyterlab/coreutils": "~5.5.2",
-        "@jupyterlite/kernel": "^0.1.0-beta.18",
-        "@jupyterlite/licenses": "^0.1.0-beta.18",
-        "@jupyterlite/localforage": "^0.1.0-beta.18",
-        "@jupyterlite/server": "^0.1.0-beta.18",
-        "@jupyterlite/session": "^0.1.0-beta.18",
-        "@jupyterlite/settings": "^0.1.0-beta.18",
-        "@jupyterlite/translation": "^0.1.0-beta.18"
+        "@lumino/commands": "^1.19.0",
+        "@lumino/coreutils": "^1.11.0",
+        "@lumino/disposable": "^1.10.0",
+        "@lumino/properties": "^1.8.0",
+        "@lumino/signaling": "^1.10.0"
       }
     },
     "node_modules/@jupyterlite/server/node_modules/ajv": {
@@ -6411,11 +6395,14 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dependencies": {
-        "@jupyterlab/coreutils": "~5.5.2",
-        "@jupyterlab/services": "~6.5.2",
-        "@jupyterlite/kernel": "^0.1.0-beta.18",
-        "@lumino/algorithm": "^1.9.1",
-        "@lumino/coreutils": "^1.12.0"
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/@jupyterlite/server/node_modules/json-schema-traverse": {
@@ -6424,13 +6411,13 @@
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
     },
     "node_modules/@jupyterlite/session": {
-      "version": "0.1.0-beta.18",
-      "resolved": "https://registry.npmjs.org/@jupyterlite/session/-/session-0.1.0-beta.18.tgz",
-      "integrity": "sha512-1ZnYGJRo90YmpcTgVQZUpYp8q4tmntB4l63IcpFJGbF4ciL+1bjZ2JUgWTJAshjHaXxbdFQCqQMfI+zMH+nVQw==",
+      "version": "0.1.0-rc.0",
+      "resolved": "https://registry.npmjs.org/@jupyterlite/session/-/session-0.1.0-rc.0.tgz",
+      "integrity": "sha512-RSWUREA2+56D0nsKT78/BMFzTPjhAdJnccOAK43Kz7u7KOF2IKQEr2NlmqbdWjP5CoF7NO7gFS2xellqWCdpRg==",
       "dependencies": {
-        "@jupyterlab/coreutils": "~5.5.2",
-        "@jupyterlab/services": "~6.5.2",
-        "@jupyterlite/kernel": "^0.1.0-beta.18",
+        "@jupyterlab/coreutils": "~5.5.3",
+        "@jupyterlab/services": "~6.5.3",
+        "@jupyterlite/kernel": "^0.1.0-rc.0",
         "@lumino/algorithm": "^1.9.1",
         "@lumino/coreutils": "^1.12.0"
       }
@@ -6469,13 +6456,13 @@
       }
     },
     "node_modules/@jupyterlite/settings": {
-      "version": "0.1.0-beta.18",
-      "resolved": "https://registry.npmjs.org/@jupyterlite/settings/-/settings-0.1.0-beta.18.tgz",
-      "integrity": "sha512-msTXN8auojgjFu2j411Tvp8uyKgjEyr0TSigJ8ndS4mW7zxT4oeN5tMaqwr/wuTjNclfoveRxprDz8T5VXr+Hg==",
+      "version": "0.1.0-rc.0",
+      "resolved": "https://registry.npmjs.org/@jupyterlite/settings/-/settings-0.1.0-rc.0.tgz",
+      "integrity": "sha512-BrX1tXc3OHsXUYIacLDFHzPn2enfoy8UdrZkFFpfaAZAXFZ0Xz0UlJGyXYaI2WSEDZUEcMc6eKo48FKxnhgGow==",
       "dependencies": {
-        "@jupyterlab/coreutils": "~5.5.2",
-        "@jupyterlab/settingregistry": "~3.5.2",
-        "@jupyterlite/localforage": "^0.1.0-beta.18",
+        "@jupyterlab/coreutils": "~5.5.3",
+        "@jupyterlab/settingregistry": "~3.5.3",
+        "@jupyterlite/localforage": "^0.1.0-rc.0",
         "@lumino/coreutils": "^1.12.0",
         "json5": "^2.2.0",
         "localforage": "^1.9.0"
@@ -6530,11 +6517,11 @@
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
     },
     "node_modules/@jupyterlite/translation": {
-      "version": "0.1.0-beta.18",
-      "resolved": "https://registry.npmjs.org/@jupyterlite/translation/-/translation-0.1.0-beta.18.tgz",
-      "integrity": "sha512-FmTSWwjeM2jaFN7b8a6Pnk6YR5QJwZPZQCSNpWxlowgnT5V9mPtbSukr7iv7VylFWfHVCaihTJtln9+0gdsDqw==",
+      "version": "0.1.0-rc.0",
+      "resolved": "https://registry.npmjs.org/@jupyterlite/translation/-/translation-0.1.0-rc.0.tgz",
+      "integrity": "sha512-cqKDAlYYW1nP2sbMBUDx0rJ4k266UDVS9EI8osOJYcVc2fdO+nUM0h+Zzp8PWEOdquyphajDaUdV0PniXHDmIA==",
       "dependencies": {
-        "@jupyterlab/coreutils": "~5.5.2",
+        "@jupyterlab/coreutils": "~5.5.3",
         "@lumino/coreutils": "^1.12.0"
       }
     },
@@ -33364,9 +33351,11 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "@jupyterlite/pyolite-kernel-extension": "0.1.0-beta.14",
-        "@jupyterlite/server": "0.1.0-beta.14",
-        "@jupyterlite/server-extension": "0.1.0-beta.14",
+        "@jupyterlab/coreutils": "^5.6.3",
+        "@jupyterlite/pyodide-kernel": "0.0.6",
+        "@jupyterlite/pyodide-kernel-extension": "0.0.6",
+        "@jupyterlite/server": "0.1.0-rc.0",
+        "@jupyterlite/server-extension": "0.1.0-rc.0",
         "hook-shell-script-webpack-plugin": "^0.1.4"
       },
       "devDependencies": {
@@ -36690,9 +36679,9 @@
       }
     },
     "@jupyterlab/coreutils": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/coreutils/-/coreutils-5.6.1.tgz",
-      "integrity": "sha512-nS4ixC9H53lFzdszOfZfDhlM2hlXfOtQAn6TnA/0Ra/gTBQ+LEbFIWdAp588iKuv8eKX39O/Us53T4oq24A31g==",
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/coreutils/-/coreutils-5.6.3.tgz",
+      "integrity": "sha512-jRVTpwGzP9wBNYuaZTip89FS1qbeSYrEO2qdNVdW2rs0mQHcIlu3Fkv5muMFmKYGi0XHhG3UhZiWQ7qiPw2svQ==",
       "requires": {
         "@lumino/coreutils": "^1.11.0",
         "@lumino/disposable": "^1.10.0",
@@ -38318,13 +38307,13 @@
       }
     },
     "@jupyterlite/contents": {
-      "version": "0.1.0-beta.18",
-      "resolved": "https://registry.npmjs.org/@jupyterlite/contents/-/contents-0.1.0-beta.18.tgz",
-      "integrity": "sha512-O6iOFD8MwfB3xOa2De1JtIIbdn63dXio40g2XnQlLbH3hPgUeTE2p1Vl9VjTQmULH/e3SjtJAjFpKYgTfkMr0g==",
+      "version": "0.1.0-rc.0",
+      "resolved": "https://registry.npmjs.org/@jupyterlite/contents/-/contents-0.1.0-rc.0.tgz",
+      "integrity": "sha512-B/TZboRyIW+/+4L4Ult6oBLu1netzNDO2QTWNJXEZYnYll2tH27KKh5puV+hbihGvZzNBmqGNIJiaPKYQghPag==",
       "requires": {
-        "@jupyterlab/nbformat": "~3.5.2",
-        "@jupyterlab/services": "~6.5.2",
-        "@jupyterlite/localforage": "^0.1.0-beta.18",
+        "@jupyterlab/nbformat": "~3.5.3",
+        "@jupyterlab/services": "~6.5.3",
+        "@jupyterlite/localforage": "^0.1.0-rc.0",
         "@lumino/coreutils": "^1.12.0",
         "@types/emscripten": "^1.39.6",
         "localforage": "^1.9.0",
@@ -38366,13 +38355,13 @@
       }
     },
     "@jupyterlite/kernel": {
-      "version": "0.1.0-beta.18",
-      "resolved": "https://registry.npmjs.org/@jupyterlite/kernel/-/kernel-0.1.0-beta.18.tgz",
-      "integrity": "sha512-GHZMBee085Z1BYyBIm3tJt2Le1K3WCFZRihG/99Xj0l3gaY8SGGvvUHuMNirFwyjmghXYdfckYafEcZouIAjnQ==",
+      "version": "0.1.0-rc.0",
+      "resolved": "https://registry.npmjs.org/@jupyterlite/kernel/-/kernel-0.1.0-rc.0.tgz",
+      "integrity": "sha512-j7Cc4tZQzpbTlbw+TLSKpfADDV1gNFuwt8wSUkik87w3V2WkgmQaeVvqNQc20qkAqjoJJasdqpx9I/n7kiNzUw==",
       "requires": {
-        "@jupyterlab/coreutils": "~5.5.2",
-        "@jupyterlab/observables": "~4.5.2",
-        "@jupyterlab/services": "~6.5.2",
+        "@jupyterlab/coreutils": "~5.5.3",
+        "@jupyterlab/observables": "~4.5.3",
+        "@jupyterlab/services": "~6.5.3",
         "@lumino/coreutils": "^1.12.0",
         "@lumino/disposable": "^1.10.1",
         "@lumino/signaling": "^1.10.1",
@@ -38429,11 +38418,11 @@
       }
     },
     "@jupyterlite/licenses": {
-      "version": "0.1.0-beta.18",
-      "resolved": "https://registry.npmjs.org/@jupyterlite/licenses/-/licenses-0.1.0-beta.18.tgz",
-      "integrity": "sha512-OnrAR2LP5ryam/v7jDoarxMv4VbEpoz4Ll8ccU+emCCI4iCrpWwEoDAxFCMl9cFVuzPiTYy0z6nIk18kkf3flw==",
+      "version": "0.1.0-rc.0",
+      "resolved": "https://registry.npmjs.org/@jupyterlite/licenses/-/licenses-0.1.0-rc.0.tgz",
+      "integrity": "sha512-3j1u029+e0HUgnsc7CwTME0BDJu5Xoqlq5x1xOS1ZeLrDEY3zSwo6HufI9pEHb1Flj4pX2bIBybimThEfwtj7Q==",
       "requires": {
-        "@jupyterlab/coreutils": "~5.5.2"
+        "@jupyterlab/coreutils": "~5.5.3"
       },
       "dependencies": {
         "@jupyterlab/coreutils": {
@@ -38453,11 +38442,11 @@
       }
     },
     "@jupyterlite/localforage": {
-      "version": "0.1.0-beta.18",
-      "resolved": "https://registry.npmjs.org/@jupyterlite/localforage/-/localforage-0.1.0-beta.18.tgz",
-      "integrity": "sha512-ukPXjs+thOG86IPoZmHQOBfNj1WfS4BgpRX1els6zL0yWITkpsLAju0LTF9A5Hsu0VdrtNq5KPvhmGShsZmJ7Q==",
+      "version": "0.1.0-rc.0",
+      "resolved": "https://registry.npmjs.org/@jupyterlite/localforage/-/localforage-0.1.0-rc.0.tgz",
+      "integrity": "sha512-aMsg8xta8ptzBGA/kfMHzuUzQPsP7Gt1vXS7TwtCTewUfbr0E5S4vjsGEvwdz/0ELtqundkeaOY5BnCt7osXgQ==",
       "requires": {
-        "@jupyterlab/coreutils": "~5.5.2",
+        "@jupyterlab/coreutils": "~5.5.3",
         "@lumino/coreutils": "^1.5.3",
         "localforage": "^1.9.0",
         "localforage-memoryStorageDriver": "^0.9.2"
@@ -38479,68 +38468,53 @@
         }
       }
     },
-    "@jupyterlite/pyolite-kernel": {
-      "version": "0.1.0-beta.18",
-      "resolved": "https://registry.npmjs.org/@jupyterlite/pyolite-kernel/-/pyolite-kernel-0.1.0-beta.18.tgz",
-      "integrity": "sha512-CsUugrlRoD+naCbOYEuhLecL9YgwH6r5TDeVfBHtlBzzP2MR+KPnwHSXbx7WiDVwzRVcG0pFrzGvRs0CQ0Rvrw==",
+    "@jupyterlite/pyodide-kernel": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@jupyterlite/pyodide-kernel/-/pyodide-kernel-0.0.6.tgz",
+      "integrity": "sha512-zXKSNWOhTQQXn4vCpZTDNBHcwCwKqPYAxQ4P4jNCMbtkCjFAauO2biAODbFdKseS/k1fP2Xy0MBGlmLK115tgA==",
       "requires": {
         "@jupyterlite/contents": "^0.1.0-beta.18",
         "@jupyterlite/kernel": "^0.1.0-beta.18",
         "comlink": "^4.3.1"
       }
     },
-    "@jupyterlite/pyolite-kernel-extension": {
-      "version": "0.1.0-beta.14",
-      "resolved": "https://registry.npmjs.org/@jupyterlite/pyolite-kernel-extension/-/pyolite-kernel-extension-0.1.0-beta.14.tgz",
-      "integrity": "sha512-OmE9ceijWg4bKbw0uLoH89ES6N0LyYEoK8vNBfOuXM6+gF1uUgQfoO6BGHK0Rle0I1t1N5EV0tcZcZ3MqOZvDQ==",
+    "@jupyterlite/pyodide-kernel-extension": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@jupyterlite/pyodide-kernel-extension/-/pyodide-kernel-extension-0.0.6.tgz",
+      "integrity": "sha512-kQX0dOESiLWfQ3eAzprTV5vTN7tbrI86AvzEtDCUchplfvwvyh21DueQ275TrO7/NoQAZ2A6GCrS3vJLHgRPpQ==",
       "requires": {
-        "@jupyterlab/coreutils": "~5.4.6",
-        "@jupyterlite/kernel": "^0.1.0-beta.14",
-        "@jupyterlite/pyolite-kernel": "^0.1.0-beta.14",
-        "@jupyterlite/server": "^0.1.0-beta.14"
-      },
-      "dependencies": {
-        "@jupyterlab/coreutils": {
-          "version": "5.4.8",
-          "resolved": "https://registry.npmjs.org/@jupyterlab/coreutils/-/coreutils-5.4.8.tgz",
-          "integrity": "sha512-UICv9nBCL+thSSOFlLWGjPm+UTT1ioPq+pOMjgn0E/DPliUMAMKtrAU5viAbRhITGAU55uL2KH9ijMUIc6o3xA==",
-          "requires": {
-            "@lumino/coreutils": "^1.11.0",
-            "@lumino/disposable": "^1.10.0",
-            "@lumino/signaling": "^1.10.0",
-            "minimist": "~1.2.0",
-            "moment": "^2.24.0",
-            "path-browserify": "^1.0.0",
-            "url-parse": "~1.5.1"
-          }
-        }
+        "@jupyterlab/coreutils": "^5.5.2",
+        "@jupyterlite/contents": "^0.1.0-beta.18",
+        "@jupyterlite/kernel": "^0.1.0-beta.18",
+        "@jupyterlite/pyodide-kernel": "^0.0.6",
+        "@jupyterlite/server": "^0.1.0-beta.18"
       }
     },
     "@jupyterlite/server": {
-      "version": "0.1.0-beta.14",
-      "resolved": "https://registry.npmjs.org/@jupyterlite/server/-/server-0.1.0-beta.14.tgz",
-      "integrity": "sha512-fMW6+jrbbo5XuCaQ79cnZhQEj6kY6bwUtjrOluG5YTrm3IWfEtIZvxwQAbq3GeEiYIih02TftFmUJajRII3q+g==",
+      "version": "0.1.0-rc.0",
+      "resolved": "https://registry.npmjs.org/@jupyterlite/server/-/server-0.1.0-rc.0.tgz",
+      "integrity": "sha512-pKmxbAtEM0JQW9zjrAkwd3L7dpnhPT0XXsCuBorJK7YMvTFmmi/xHQa+Zcif+9DViay51AALR5bFXkc6GTQDxw==",
       "requires": {
-        "@jupyterlab/coreutils": "~5.4.6",
-        "@jupyterlab/nbformat": "~3.4.8",
-        "@jupyterlab/observables": "~4.4.4",
-        "@jupyterlab/services": "~6.4.6",
-        "@jupyterlab/settingregistry": "~3.4.8",
-        "@jupyterlab/statedb": "~3.4.8",
-        "@jupyterlite/contents": "^0.1.0-beta.14",
-        "@jupyterlite/kernel": "^0.1.0-beta.14",
-        "@jupyterlite/session": "^0.1.0-beta.14",
-        "@jupyterlite/settings": "^0.1.0-beta.14",
-        "@jupyterlite/translation": "^0.1.0-beta.14",
+        "@jupyterlab/coreutils": "~5.5.3",
+        "@jupyterlab/nbformat": "~3.5.3",
+        "@jupyterlab/observables": "~4.5.3",
+        "@jupyterlab/services": "~6.5.3",
+        "@jupyterlab/settingregistry": "~3.5.3",
+        "@jupyterlab/statedb": "~3.5.3",
+        "@jupyterlite/contents": "^0.1.0-rc.0",
+        "@jupyterlite/kernel": "^0.1.0-rc.0",
+        "@jupyterlite/session": "^0.1.0-rc.0",
+        "@jupyterlite/settings": "^0.1.0-rc.0",
+        "@jupyterlite/translation": "^0.1.0-rc.0",
         "@lumino/application": "^1.27.0",
         "@lumino/coreutils": "^1.12.0",
         "mock-socket": "^9.1.0"
       },
       "dependencies": {
         "@jupyterlab/coreutils": {
-          "version": "5.4.8",
-          "resolved": "https://registry.npmjs.org/@jupyterlab/coreutils/-/coreutils-5.4.8.tgz",
-          "integrity": "sha512-UICv9nBCL+thSSOFlLWGjPm+UTT1ioPq+pOMjgn0E/DPliUMAMKtrAU5viAbRhITGAU55uL2KH9ijMUIc6o3xA==",
+          "version": "5.5.3",
+          "resolved": "https://registry.npmjs.org/@jupyterlab/coreutils/-/coreutils-5.5.3.tgz",
+          "integrity": "sha512-GCAymoQAwscE8MGH7eb366bRxvWawOXKFeyq642SAtl0/xWty8Kem56UfdUdyTCRzxwYW5r1sJuRHBvbTjnvUA==",
           "requires": {
             "@lumino/coreutils": "^1.11.0",
             "@lumino/disposable": "^1.10.0",
@@ -38552,17 +38526,17 @@
           }
         },
         "@jupyterlab/nbformat": {
-          "version": "3.4.8",
-          "resolved": "https://registry.npmjs.org/@jupyterlab/nbformat/-/nbformat-3.4.8.tgz",
-          "integrity": "sha512-RcyITAagwXMIWqehpctb43mVB1H3LrTfikGvykLICmA5AfT+byhooCDN4d+ipg4rkeioUmEgX+2uTfForCsJWQ==",
+          "version": "3.5.3",
+          "resolved": "https://registry.npmjs.org/@jupyterlab/nbformat/-/nbformat-3.5.3.tgz",
+          "integrity": "sha512-7HIdRXrm5BKrP4P1cT+b34BFiqmEcr5fJyyBW6nIm3DXh9ZNTKhQUN8vGvkL7qTXZFXmdhc//eTSZUPQ3F3JcA==",
           "requires": {
             "@lumino/coreutils": "^1.11.0"
           }
         },
         "@jupyterlab/observables": {
-          "version": "4.4.8",
-          "resolved": "https://registry.npmjs.org/@jupyterlab/observables/-/observables-4.4.8.tgz",
-          "integrity": "sha512-TT7YQNxvLnfuzbHQjoovfVN02dXDG/zxfWiA1RkycAJnQ/aTgRtEMlLMs7dUqNCh6ej6zNQOUEduJInro/OL4A==",
+          "version": "4.5.3",
+          "resolved": "https://registry.npmjs.org/@jupyterlab/observables/-/observables-4.5.3.tgz",
+          "integrity": "sha512-WERivf/gr2ZMGCXEiJpgv4AGVG8ovKzdg/tIgzrf72eB4Jq5WXMy4r5GLvM+g3PkiiG8o50C2t/SXcUlvNDTaw==",
           "requires": {
             "@lumino/algorithm": "^1.9.0",
             "@lumino/coreutils": "^1.11.0",
@@ -38572,15 +38546,15 @@
           }
         },
         "@jupyterlab/services": {
-          "version": "6.4.8",
-          "resolved": "https://registry.npmjs.org/@jupyterlab/services/-/services-6.4.8.tgz",
-          "integrity": "sha512-/acj4d1A1V9KDN+k4CUokOA8e/IxaoJW2B+FJxVnTZvVOBh7093EIG+HYL1SQuQ8CUc2T4DNiq9mG3skiSe2fQ==",
+          "version": "6.5.3",
+          "resolved": "https://registry.npmjs.org/@jupyterlab/services/-/services-6.5.3.tgz",
+          "integrity": "sha512-9wIVzKeAvgx9J0g9DoG96yauG+HU4/ms28DM+7iS34/akoHSM17czWGGnmKY0Y3MyZ22up7aZelCthP+WiAQxQ==",
           "requires": {
-            "@jupyterlab/coreutils": "^5.4.8",
-            "@jupyterlab/nbformat": "^3.4.8",
-            "@jupyterlab/observables": "^4.4.8",
-            "@jupyterlab/settingregistry": "^3.4.8",
-            "@jupyterlab/statedb": "^3.4.8",
+            "@jupyterlab/coreutils": "^5.5.3",
+            "@jupyterlab/nbformat": "^3.5.3",
+            "@jupyterlab/observables": "^4.5.3",
+            "@jupyterlab/settingregistry": "^3.5.3",
+            "@jupyterlab/statedb": "^3.5.3",
             "@lumino/algorithm": "^1.9.0",
             "@lumino/coreutils": "^1.11.0",
             "@lumino/disposable": "^1.10.0",
@@ -38591,11 +38565,11 @@
           }
         },
         "@jupyterlab/settingregistry": {
-          "version": "3.4.8",
-          "resolved": "https://registry.npmjs.org/@jupyterlab/settingregistry/-/settingregistry-3.4.8.tgz",
-          "integrity": "sha512-w9MNFivKXUOLrEvWckpcYm3XAZr0sbcKQ33SkftaLSQODsFlUwkcsjCPJJATVyxiWXAsCAgUlOKdNcqWxYXvOA==",
+          "version": "3.5.3",
+          "resolved": "https://registry.npmjs.org/@jupyterlab/settingregistry/-/settingregistry-3.5.3.tgz",
+          "integrity": "sha512-PWkISgGHikSaOEOiPVIDCcnLdiuXAcFdI7ZPLWoaq0v+NykemenQ5+MXOEaEOgf3KUAE8PFAGNr+3indbwFXNw==",
           "requires": {
-            "@jupyterlab/statedb": "^3.4.8",
+            "@jupyterlab/statedb": "^3.5.3",
             "@lumino/commands": "^1.19.0",
             "@lumino/coreutils": "^1.11.0",
             "@lumino/disposable": "^1.10.0",
@@ -38605,9 +38579,9 @@
           }
         },
         "@jupyterlab/statedb": {
-          "version": "3.4.8",
-          "resolved": "https://registry.npmjs.org/@jupyterlab/statedb/-/statedb-3.4.8.tgz",
-          "integrity": "sha512-PMlo+x4R8uXPH1BgCJUVVIj/H8SY9scGJU0pqHhYa6mm3R2EHNAwr8JxyqGjAqT3C0VCCCIDzHtQ3f9inW+OXg==",
+          "version": "3.5.3",
+          "resolved": "https://registry.npmjs.org/@jupyterlab/statedb/-/statedb-3.5.3.tgz",
+          "integrity": "sha512-QlFLcSzOJUjjwiXjgv5dQVHTRXXBT5+e/kJKVLddi80li/p0hBmKQHP+9e15Ql+i599uyoE6zE7lyMRPHrO98w==",
           "requires": {
             "@lumino/commands": "^1.19.0",
             "@lumino/coreutils": "^1.11.0",
@@ -38635,24 +38609,24 @@
       }
     },
     "@jupyterlite/server-extension": {
-      "version": "0.1.0-beta.14",
-      "resolved": "https://registry.npmjs.org/@jupyterlite/server-extension/-/server-extension-0.1.0-beta.14.tgz",
-      "integrity": "sha512-cs0V1wzIy5ZOrn3RUtOltrlaAthAiNf1XNfvu4klpjoZeBoIYOPo0x8xrmNonEVq8AkVw8TZrR9RLZws4p41HQ==",
+      "version": "0.1.0-rc.0",
+      "resolved": "https://registry.npmjs.org/@jupyterlite/server-extension/-/server-extension-0.1.0-rc.0.tgz",
+      "integrity": "sha512-N2BTHRiV6sxpc6QO+5gk5zfxotZqvOoTNbxc180GhnRXJv1RUuCQePCLDIwpbqsGbjt91yvnai2KhZofayWZKA==",
       "requires": {
-        "@jupyterlab/coreutils": "~5.4.6",
-        "@jupyterlite/kernel": "^0.1.0-beta.14",
-        "@jupyterlite/licenses": "^0.1.0-beta.14",
-        "@jupyterlite/localforage": "^0.1.0-beta.14",
-        "@jupyterlite/server": "^0.1.0-beta.14",
-        "@jupyterlite/session": "^0.1.0-beta.14",
-        "@jupyterlite/settings": "^0.1.0-beta.14",
-        "@jupyterlite/translation": "^0.1.0-beta.14"
+        "@jupyterlab/coreutils": "~5.5.3",
+        "@jupyterlite/kernel": "^0.1.0-rc.0",
+        "@jupyterlite/licenses": "^0.1.0-rc.0",
+        "@jupyterlite/localforage": "^0.1.0-rc.0",
+        "@jupyterlite/server": "^0.1.0-rc.0",
+        "@jupyterlite/session": "^0.1.0-rc.0",
+        "@jupyterlite/settings": "^0.1.0-rc.0",
+        "@jupyterlite/translation": "^0.1.0-rc.0"
       },
       "dependencies": {
         "@jupyterlab/coreutils": {
-          "version": "5.4.8",
-          "resolved": "https://registry.npmjs.org/@jupyterlab/coreutils/-/coreutils-5.4.8.tgz",
-          "integrity": "sha512-UICv9nBCL+thSSOFlLWGjPm+UTT1ioPq+pOMjgn0E/DPliUMAMKtrAU5viAbRhITGAU55uL2KH9ijMUIc6o3xA==",
+          "version": "5.5.3",
+          "resolved": "https://registry.npmjs.org/@jupyterlab/coreutils/-/coreutils-5.5.3.tgz",
+          "integrity": "sha512-GCAymoQAwscE8MGH7eb366bRxvWawOXKFeyq642SAtl0/xWty8Kem56UfdUdyTCRzxwYW5r1sJuRHBvbTjnvUA==",
           "requires": {
             "@lumino/coreutils": "^1.11.0",
             "@lumino/disposable": "^1.10.0",
@@ -38666,13 +38640,13 @@
       }
     },
     "@jupyterlite/session": {
-      "version": "0.1.0-beta.18",
-      "resolved": "https://registry.npmjs.org/@jupyterlite/session/-/session-0.1.0-beta.18.tgz",
-      "integrity": "sha512-1ZnYGJRo90YmpcTgVQZUpYp8q4tmntB4l63IcpFJGbF4ciL+1bjZ2JUgWTJAshjHaXxbdFQCqQMfI+zMH+nVQw==",
+      "version": "0.1.0-rc.0",
+      "resolved": "https://registry.npmjs.org/@jupyterlite/session/-/session-0.1.0-rc.0.tgz",
+      "integrity": "sha512-RSWUREA2+56D0nsKT78/BMFzTPjhAdJnccOAK43Kz7u7KOF2IKQEr2NlmqbdWjP5CoF7NO7gFS2xellqWCdpRg==",
       "requires": {
-        "@jupyterlab/coreutils": "~5.5.2",
-        "@jupyterlab/services": "~6.5.2",
-        "@jupyterlite/kernel": "^0.1.0-beta.18",
+        "@jupyterlab/coreutils": "~5.5.3",
+        "@jupyterlab/services": "~6.5.3",
+        "@jupyterlite/kernel": "^0.1.0-rc.0",
         "@lumino/algorithm": "^1.9.1",
         "@lumino/coreutils": "^1.12.0"
       },
@@ -38713,13 +38687,13 @@
       }
     },
     "@jupyterlite/settings": {
-      "version": "0.1.0-beta.18",
-      "resolved": "https://registry.npmjs.org/@jupyterlite/settings/-/settings-0.1.0-beta.18.tgz",
-      "integrity": "sha512-msTXN8auojgjFu2j411Tvp8uyKgjEyr0TSigJ8ndS4mW7zxT4oeN5tMaqwr/wuTjNclfoveRxprDz8T5VXr+Hg==",
+      "version": "0.1.0-rc.0",
+      "resolved": "https://registry.npmjs.org/@jupyterlite/settings/-/settings-0.1.0-rc.0.tgz",
+      "integrity": "sha512-BrX1tXc3OHsXUYIacLDFHzPn2enfoy8UdrZkFFpfaAZAXFZ0Xz0UlJGyXYaI2WSEDZUEcMc6eKo48FKxnhgGow==",
       "requires": {
-        "@jupyterlab/coreutils": "~5.5.2",
-        "@jupyterlab/settingregistry": "~3.5.2",
-        "@jupyterlite/localforage": "^0.1.0-beta.18",
+        "@jupyterlab/coreutils": "~5.5.3",
+        "@jupyterlab/settingregistry": "~3.5.3",
+        "@jupyterlite/localforage": "^0.1.0-rc.0",
         "@lumino/coreutils": "^1.12.0",
         "json5": "^2.2.0",
         "localforage": "^1.9.0"
@@ -38772,11 +38746,11 @@
       }
     },
     "@jupyterlite/translation": {
-      "version": "0.1.0-beta.18",
-      "resolved": "https://registry.npmjs.org/@jupyterlite/translation/-/translation-0.1.0-beta.18.tgz",
-      "integrity": "sha512-FmTSWwjeM2jaFN7b8a6Pnk6YR5QJwZPZQCSNpWxlowgnT5V9mPtbSukr7iv7VylFWfHVCaihTJtln9+0gdsDqw==",
+      "version": "0.1.0-rc.0",
+      "resolved": "https://registry.npmjs.org/@jupyterlite/translation/-/translation-0.1.0-rc.0.tgz",
+      "integrity": "sha512-cqKDAlYYW1nP2sbMBUDx0rJ4k266UDVS9EI8osOJYcVc2fdO+nUM0h+Zzp8PWEOdquyphajDaUdV0PniXHDmIA==",
       "requires": {
-        "@jupyterlab/coreutils": "~5.5.2",
+        "@jupyterlab/coreutils": "~5.5.3",
         "@lumino/coreutils": "^1.12.0"
       },
       "dependencies": {
@@ -57051,9 +57025,11 @@
     "thebe-lite": {
       "version": "file:packages/lite",
       "requires": {
-        "@jupyterlite/pyolite-kernel-extension": "0.1.0-beta.14",
-        "@jupyterlite/server": "0.1.0-beta.14",
-        "@jupyterlite/server-extension": "0.1.0-beta.14",
+        "@jupyterlab/coreutils": "^5.6.3",
+        "@jupyterlite/pyodide-kernel": "0.0.6",
+        "@jupyterlite/pyodide-kernel-extension": "0.0.6",
+        "@jupyterlite/server": "0.1.0-rc.0",
+        "@jupyterlite/server-extension": "0.1.0-rc.0",
         "current-script-polyfill": "^1.0.0",
         "hook-shell-script-webpack-plugin": "^0.1.4",
         "ignore-emit-webpack-plugin": "^2.0.6",

--- a/packages/lite/bin/fetchServiceWorker.sh
+++ b/packages/lite/bin/fetchServiceWorker.sh
@@ -1,2 +1,0 @@
-# pinned to the latest service worker script from juptyerlite
-curl -s https://raw.githubusercontent.com/jupyterlite/jupyterlite/004c69cc0612d4bef51c1dc51b3e98ee27dd3a1f/app/services.js --output dist/lib/services.js

--- a/packages/lite/package.json
+++ b/packages/lite/package.json
@@ -40,9 +40,11 @@
   },
   "homepage": "https://github.com/executablebooks/thebe#readme",
   "dependencies": {
-    "@jupyterlite/pyolite-kernel-extension": "0.1.0-beta.18",
-    "@jupyterlite/server": "0.1.0-beta.18",
-    "@jupyterlite/server-extension": "0.1.0-beta.18",
+    "@jupyterlab/coreutils": "^5.6.3",
+    "@jupyterlite/pyodide-kernel": "0.0.6",
+    "@jupyterlite/pyodide-kernel-extension": "0.0.6",
+    "@jupyterlite/server": "0.1.0-rc.0",
+    "@jupyterlite/server-extension": "0.1.0-rc.0",
     "hook-shell-script-webpack-plugin": "^0.1.4"
   },
   "devDependencies": {

--- a/packages/lite/package.json
+++ b/packages/lite/package.json
@@ -40,9 +40,9 @@
   },
   "homepage": "https://github.com/executablebooks/thebe#readme",
   "dependencies": {
-    "@jupyterlite/pyolite-kernel-extension": "0.1.0-beta.14",
-    "@jupyterlite/server": "0.1.0-beta.14",
-    "@jupyterlite/server-extension": "0.1.0-beta.14",
+    "@jupyterlite/pyolite-kernel-extension": "0.1.0-beta.18",
+    "@jupyterlite/server": "0.1.0-beta.18",
+    "@jupyterlite/server-extension": "0.1.0-beta.18",
     "hook-shell-script-webpack-plugin": "^0.1.4"
   },
   "devDependencies": {

--- a/packages/lite/package.json
+++ b/packages/lite/package.json
@@ -8,7 +8,7 @@
     "clean": "rm -rf ./dist",
     "build:bundle": "webpack --config webpack.config.cjs",
     "build:post:shuffle": "./bin/shufflePyolitePaths.sh",
-    "build:post:service": "./bin/fetchServiceWorker.sh",
+    "build:post:contents": "./bin/stubContentsApi.js",
     "declarations": "tsc  --project ./tsconfig.json --declaration --emitDeclarationOnly --outDir dist/types",
     "build": "npm-run-all -l clean -p build:bundle declarations",
     "build:watch": "npm run build:bundle -- -w"

--- a/packages/lite/src/empty.js
+++ b/packages/lite/src/empty.js
@@ -1,0 +1,2 @@
+// empty module for shims
+module.exports = {};

--- a/packages/lite/src/index.ts
+++ b/packages/lite/src/index.ts
@@ -14,7 +14,7 @@ function setupThebeLite() {
 if (typeof window !== 'undefined') {
   console.debug('window is defined, setting up thebe-lite');
   setupThebeLite();
-  console.log('window.thebeLite', window.thebeLite);
+  console.debug('window.thebeLite', window.thebeLite);
 }
 
 export * from './types';

--- a/packages/lite/src/jlite.ts
+++ b/packages/lite/src/jlite.ts
@@ -33,8 +33,17 @@ function* activePlugins(extension: any) {
   }
 }
 
+/**
+ * Example litePluginSettings shape
+ * 
+ * '@jupyterlite/pyodide-kernel-extension:kernel': {
+        pipliteUrls: ['https://unpkg.com/@jupyterlite/pyodide-kernel@0.0.6/pypi/all.json'],
+        piplistWheelUrl: 'https://some-url.com'
+      }
+ * 
+ */
+
 type LiteServerConfig = {
-  federatedExtensions: Record<string, any>;
   litePluginSettings: Record<string, any>;
 };
 
@@ -48,14 +57,9 @@ export async function startJupyterLiteServer(config?: LiteServerConfig): Promise
    * Do not rely on a configuration being on the document body, accept configuration via arguments
    * and set options on the page config directly
    */
-  PageConfig.setOption(
-    'litePluginSettings',
-    JSON.stringify({
-      '@jupyterlite/pyodide-kernel-extension:kernel': {
-        pipliteUrls: ['https://unpkg.com/@jupyterlite/pyodide-kernel@0.0.6/pypi/all.json'],
-      },
-    }),
-  );
+  if (config?.litePluginSettings) {
+    PageConfig.setOption('litePluginSettings', JSON.stringify(config.litePluginSettings));
+  }
 
   /**
    * Seems like there are 4 different extensions we may want to handle

--- a/packages/lite/src/jlite.ts
+++ b/packages/lite/src/jlite.ts
@@ -1,38 +1,101 @@
 import type { ServiceManager } from '@jupyterlab/services';
+import { PageConfig } from '@jupyterlab/coreutils';
 import { JupyterLiteServer } from '@jupyterlite/server';
 
-const serverExtensions = [
-  import('@jupyterlite/pyolite-kernel-extension'),
-  import('@jupyterlite/server-extension'),
-];
+const serverExtensions = [import('@jupyterlite/server-extension')];
 
-export async function startJupyterLiteServer(): Promise<ServiceManager> {
-  const litePluginsToRegister: JupyterLiteServer.IPluginModule[] = [];
+async function createModule(scope: string, module: string) {
+  try {
+    const factory = await (window as any)._JUPYTERLAB[scope].get(module);
+    return factory();
+  } catch (e) {
+    console.warn(`Failed to create module: package: ${scope}; module: ${module}`);
+    throw e;
+  }
+}
+
+/**
+ * Iterate over active plugins in an extension.
+ */
+function* activePlugins(extension: any) {
+  // Handle commonjs or es2015 modules
+  let exports;
+  if (Object.prototype.hasOwnProperty.call(extension, '__esModule')) {
+    exports = extension.default;
+  } else {
+    // CommonJS exports.
+    exports = extension;
+  }
+
+  const plugins = Array.isArray(exports) ? exports : [exports];
+  for (const plugin of plugins) {
+    yield plugin;
+  }
+}
+
+type LiteServerConfig = {
+  federatedExtensions: Record<string, any>;
+  litePluginSettings: Record<string, any>;
+};
+
+export async function startJupyterLiteServer(config?: LiteServerConfig): Promise<ServiceManager> {
+  /**
+   * Do not rely on a configuration being on the document body, accept configuration via arguments
+   * and set options on the page config directly
+   */
+  PageConfig.setOption(
+    'litePluginSettings',
+    JSON.stringify({
+      '@jupyterlite/pyodide-kernel-extension:kernel': {
+        pipliteUrls: ['https://unpkg.com/@jupyterlite/pyodide-kernel@0.0.6/pypi/all.json'],
+      },
+    }),
+  );
 
   /**
-   * Iterate over active plugins in an extension.
+   * Seems like there are 4 different extensions we may want to handle
+   *
+   * liteExtension - essential, as these are how kernels are added
+   * federatedExtension - general jupyterlab extensions
+   * federatedMimeExtension - render extensions? e.g. @jupyterlab/javascript-extension, @jupyterlab/json-extension
+   * federatedStyles - ?
+   *
+   * TODO we're not suppporting all of these yet
    */
-  function* activePlugins(extension: any) {
-    // Handle commonjs or es2015 modules
-    let exports;
-    if (Object.prototype.hasOwnProperty.call(extension, '__esModule')) {
-      exports = extension.default;
-    } else {
-      // CommonJS exports.
-      exports = extension;
-    }
 
-    const plugins = Array.isArray(exports) ? exports : [exports];
-    for (const plugin of plugins) {
-      yield plugin;
-    }
-  }
+  console.log('getOption', JSON.parse(PageConfig.getOption('litePluginSettings')));
+
+  const litePluginsToRegister: JupyterLiteServer.IPluginModule[] = [];
 
   // Add the base serverlite extensions
   const baseServerExtensions = await Promise.all(serverExtensions);
   baseServerExtensions.forEach((p) => {
     for (const plugin of activePlugins(p)) {
       litePluginsToRegister.push(plugin);
+    }
+  });
+
+  // TODO get federated extensions in from config argument?
+  const extensions: any[] = [];
+
+  const liteExtensionPromises: any[] = [import('@jupyterlite/pyodide-kernel-extension')];
+
+  extensions.forEach((data) => {
+    if (data.liteExtension) {
+      liteExtensionPromises.push(createModule(data.name, data.extension));
+      return;
+    }
+  });
+
+  // Add the serverlite federated extensions.
+  const federatedLiteExtensions = await Promise.allSettled(liteExtensionPromises);
+  federatedLiteExtensions.forEach((p) => {
+    if (p.status === 'fulfilled') {
+      for (const plugin of activePlugins(p.value)) {
+        litePluginsToRegister.push(plugin);
+      }
+    } else {
+      console.error(p.reason);
     }
   });
 

--- a/packages/lite/src/jlite.ts
+++ b/packages/lite/src/jlite.ts
@@ -48,14 +48,14 @@ export async function startJupyterLiteServer(config?: LiteServerConfig): Promise
    * Do not rely on a configuration being on the document body, accept configuration via arguments
    * and set options on the page config directly
    */
-  PageConfig.setOption(
-    'litePluginSettings',
-    JSON.stringify({
-      '@jupyterlite/pyodide-kernel-extension:kernel': {
-        pipliteUrls: ['https://unpkg.com/@jupyterlite/pyodide-kernel@0.0.6/pypi/all.json'],
-      },
-    }),
-  );
+  // PageConfig.setOption(
+  //   'litePluginSettings',
+  //   JSON.stringify({
+  //     '@jupyterlite/pyodide-kernel-extension:kernel': {
+  //       pipliteUrls: ['https://unpkg.com/@jupyterlite/pyodide-kernel@0.0.6/pypi/all.json'],
+  //     },
+  //   }),
+  // );
 
   /**
    * Seems like there are 4 different extensions we may want to handle
@@ -67,8 +67,6 @@ export async function startJupyterLiteServer(config?: LiteServerConfig): Promise
    *
    * TODO we're not suppporting all of these yet
    */
-
-  console.log('getOption', JSON.parse(PageConfig.getOption('litePluginSettings')));
 
   const litePluginsToRegister: JupyterLiteServer.IPluginModule[] = [];
 

--- a/packages/lite/src/jlite.ts
+++ b/packages/lite/src/jlite.ts
@@ -48,14 +48,14 @@ export async function startJupyterLiteServer(config?: LiteServerConfig): Promise
    * Do not rely on a configuration being on the document body, accept configuration via arguments
    * and set options on the page config directly
    */
-  // PageConfig.setOption(
-  //   'litePluginSettings',
-  //   JSON.stringify({
-  //     '@jupyterlite/pyodide-kernel-extension:kernel': {
-  //       pipliteUrls: ['https://unpkg.com/@jupyterlite/pyodide-kernel@0.0.6/pypi/all.json'],
-  //     },
-  //   }),
-  // );
+  PageConfig.setOption(
+    'litePluginSettings',
+    JSON.stringify({
+      '@jupyterlite/pyodide-kernel-extension:kernel': {
+        pipliteUrls: ['https://unpkg.com/@jupyterlite/pyodide-kernel@0.0.6/pypi/all.json'],
+      },
+    }),
+  );
 
   /**
    * Seems like there are 4 different extensions we may want to handle

--- a/packages/lite/src/jlite.ts
+++ b/packages/lite/src/jlite.ts
@@ -40,6 +40,11 @@ type LiteServerConfig = {
 
 export async function startJupyterLiteServer(config?: LiteServerConfig): Promise<ServiceManager> {
   /**
+   * This is sufficent to  initialise the global object?
+   */
+  PageConfig.getOption('');
+
+  /**
    * Do not rely on a configuration being on the document body, accept configuration via arguments
    * and set options on the page config directly
    */

--- a/packages/lite/webpack.config.cjs
+++ b/packages/lite/webpack.config.cjs
@@ -1,8 +1,13 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 const path = require('path');
 const webpack = require('webpack');
-const { DefinePlugin } = require('webpack');
+const { DefinePlugin, NormalModuleReplacementPlugin } = require('webpack');
 const HookShellScriptPlugin = require('hook-shell-script-webpack-plugin');
+
+const shimJS = path.resolve(__dirname, 'src', 'empty.js');
+function shim(regExp) {
+  return new NormalModuleReplacementPlugin(regExp, shimJS);
+}
 
 module.exports = {
   mode: 'production',
@@ -14,16 +19,13 @@ module.exports = {
     app: './src/index.ts',
   },
   plugins: [
+    shim(/\.(svg|ttf|eot|woff2|woff)/),
     new DefinePlugin({ 'process.env': {} }),
     new webpack.ProvidePlugin({
       currentScript: 'current-script-polyfill',
     }),
     new HookShellScriptPlugin({
-      afterEmit: [
-        'npm run build:post:shuffle',
-        'npm run build:post:service',
-        'node bin/stubContentsApi.js',
-      ],
+      afterEmit: ['node bin/stubContentsApi.js'],
     }),
   ],
   output: {

--- a/packages/lite/webpack.config.cjs
+++ b/packages/lite/webpack.config.cjs
@@ -39,6 +39,9 @@ module.exports = {
       {
         test: /pypi\/.*/,
         type: 'asset/resource',
+        generator: {
+          filename: 'pypi/[name][ext][query]',
+        },
       },
       {
         test: /\.ts$/,


### PR DESCRIPTION
The purpose of this PR is to update to using the latest `juptyerlite` codebase, this involves adjusting to the new organisation of the `@juptyerlite/pyodide-kernel` and taking steps to specify the location of the wheels to load. This should be a big improvement over the previous implementation once in place, and the objective is to be able to load the latest wheels from CDN (possibly direct from unpkg.com).

