### PR TITLE
📡 autoload mode and strip back bundled css classes and overrides

### DIFF
--- a/apps/docs-core/thebe-docs.md
+++ b/apps/docs-core/thebe-docs.md
@@ -1,0 +1,34 @@
+# Plceholder for thebe related docs
+
+## Codemirror setup
+
+The following is available in the thebe options object:
+
+```typescript
+{
+  codeMirrorConfig?: {
+    theme?: string;         (default: 'default')
+    readOnly?: boolean;     (default: false)
+    mode?: string;          (default: 'python')
+    autoRefresh?: boolean;  (default: true)
+    lineNumbers?: boolean;  (default: true)
+    styleActiveLine?: boolean;  (default: true)
+    matchBrackets?: boolean;  (default: true)
+  };
+}
+```
+
+`mode` and `readOnly` will also be read from code cells on the page, and the values provided on those cells will **override** those set in the options object
+
+### preloaded themes
+
+Only a few themes are bundled with thebe:
+
+- default
+- abcdef
+- darcula
+- idea
+
+To load additional themes, make the css available on you page and set the `theme` field to the correct theme name in the `CodeMirror` options object.
+
+Find the [full list of themes](https://codemirror.net/5/demo/theme.html) here and CDN based resources for loading them for example, for twilight here: https://unpkg.com/codemirror@5.61.1/theme/twilight.css

--- a/apps/docs-core/thebe-docs.md
+++ b/apps/docs-core/thebe-docs.md
@@ -20,6 +20,10 @@ The following is available in the thebe options object:
 
 `mode` and `readOnly` will also be read from code cells on the page, and the values provided on those cells will **override** those set in the options object
 
+### modes
+
+thebe is preloaded with the python mode and will try to load additional modes on the setting. Should this fail or to preload a mode on your page, load directly to a script tag using CDN e.g. for rust here: https://unpkg.com/browse/codemirror@5.61.1/mode/rust/rust.js
+
 ### preloaded themes
 
 Only a few themes are bundled with thebe:

--- a/apps/simple/static/index.html
+++ b/apps/simple/static/index.html
@@ -7,24 +7,22 @@
     <meta http-equiv="X-UA-Compatible" content="ie=edge" />
     <link rel="icon" href="/thebe_128x128.svg" type="image/svg+xml" />
     <script src="https://cdn.tailwindcss.com?plugins=typography,aspect-ratio,line-clamp"></script>
+    <link rel="stylesheet" href="https://unpkg.com/codemirror@5.61.1/theme/darcula.css" />
     <script type="text/x-thebe-config">
       {
         mountActivateWidget: true,
         mountStatusWidget: true,
         useJupyterLite: true,
-        useBinder: false
+        useBinder: false,
+        codeMirrorConfig: {
+          theme: 'darcula',
+        }
       }
     </script>
     <!-- this following is the thebe entrypoint script -->
     <script src="thebe-lite.min.js"></script>
     <script src="index.js"></script>
-    <link
-      rel="stylesheet"
-      href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.12/codemirror.min.css"
-      integrity="sha512-uf06llspW44/LZpHzHT6qBOIVODjWtv4MxCricRxkzvopAlSWnTf6hpZTFxuuZcuNE9CBQhqE0Seu1CoRk84nQ=="
-      crossorigin="anonymous"
-      referrerpolicy="no-referrer"
-    />
+
     <link rel="stylesheet" href="thebe.css" />
     <link rel="stylesheet" href="main.css" />
     <style>

--- a/apps/simple/static/index.html
+++ b/apps/simple/static/index.html
@@ -35,6 +35,9 @@
         margin-right: 4px;
         padding: 0 8px;
       }
+      .CodeMirror {
+        height: 500px;
+      }
     </style>
   </head>
   <body class="font-sans">

--- a/apps/simple/static/index.html
+++ b/apps/simple/static/index.html
@@ -22,7 +22,6 @@
     <!-- this following is the thebe entrypoint script -->
     <script src="thebe-lite.min.js"></script>
     <script src="index.js"></script>
-
     <link rel="stylesheet" href="thebe.css" />
     <link rel="stylesheet" href="main.css" />
     <style>

--- a/apps/simple/static/index.html
+++ b/apps/simple/static/index.html
@@ -41,7 +41,7 @@
     </style>
   </head>
   <body class="font-sans">
-    <div class="prose max-w-2xl mx-auto my-4">
+    <div class="prose max-w-3xl mx-auto my-4">
       <div><img class="mx-auto" src="./thebe_wide_logo.png" /></div>
       <h1>Simple Demos</h1>
       <div>

--- a/apps/simple/static/index.html
+++ b/apps/simple/static/index.html
@@ -108,10 +108,10 @@
           href="https://ipywidgets.readthedocs.io/en/stable/index.html"
           target="_blank"
           rel="no-referrer"
-          >ipywidgets docuementation</a
+          >ipywidgets documentation</a
         >.
       </p>
-      <div class="not-prose">
+      <div class="not-prose text-sm">
         <pre
           class="text-sm bg-black text-white rounded-lg p-4"
           data-executable="true"

--- a/apps/simple/static/lite.html
+++ b/apps/simple/static/lite.html
@@ -38,9 +38,6 @@
     />
     <script src="index.js"></script>
     <style>
-      .CodeMirror {
-        max-width: 900px;
-      }
       pre.code {
         background-color: #eee;
         padding: 16px;

--- a/apps/simple/static/main.css
+++ b/apps/simple/static/main.css
@@ -1,10 +1,3 @@
-.CodeMirror {
-  border: 1px solid black;
-  font-size: 13px;
-  margin-bottom: 3px;
-  max-width: 600px;
-}
-
 .thebe-activate,
 .thebe-status {
   margin-bottom: 8px;

--- a/packages/thebe/package.json
+++ b/packages/thebe/package.json
@@ -58,13 +58,15 @@
   },
   "homepage": "https://thebe.readthedocs.io/en/latest",
   "dependencies": {
-    "thebe-core": "^0.1.6"
+    "@jupyterlab/theme-light-extension": "^3.0.0",
+    "thebe-core": "^0.1.6",
+    "codemirror": "5.61.1",
+    "current-script-polyfill": "^1.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.12.3",
     "@babel/preset-env": "^7.12.1",
     "@jupyterlab/testutils": "^3.2.4",
-    "@jupyterlab/theme-light-extension": "^3.0.0",
     "@types/codemirror": "^5.60.5",
     "@types/expect-puppeteer": "^5.0.1",
     "@types/jest": "^29.2.1",
@@ -77,7 +79,6 @@
     "concurrently": "^6.2.1",
     "core-js": "^3.6.5",
     "css-loader": "^5.0.0",
-    "current-script-polyfill": "^1.0.0",
     "esbuild": "^0.15.6",
     "eslint-config-thebe": "*",
     "eventsource": "^2.0.2",

--- a/packages/thebe/src/codemirror.ts
+++ b/packages/thebe/src/codemirror.ts
@@ -1,0 +1,152 @@
+import CodeMirror from 'codemirror/lib/codemirror';
+import 'codemirror/lib/codemirror.css';
+import 'codemirror/mode/python/python.js';
+import 'codemirror/addon/hint/show-hint';
+import 'codemirror/addon/mode/loadMode';
+import 'codemirror/addon/display/autorefresh';
+import 'codemirror/theme/abcdef.css';
+import 'codemirror/theme/darcula.css';
+import 'codemirror/theme/idea.css';
+
+import type { Options } from './options';
+import type { IThebeCell } from 'thebe-core';
+import type { ICompleteReplyMsg } from '@jupyterlab/services/lib/kernel/messages';
+import type { CellDOMPlaceholder } from './types';
+
+interface DefaultCodeMirrorConfig {
+  theme: 'default';
+  mode: 'python';
+  readOnly: false;
+  autoRefresh: true;
+  lineNumbers: true;
+  styleActiveLine: true;
+  matchBrackets: true;
+}
+
+interface PageCodeMirrorConfig {
+  mode?: string;
+  readOnly?: boolean;
+}
+
+interface RequiredCodeMirrorConfig {
+  value: string;
+  extraKeys: {
+    'Shift-Enter': () => void;
+    'Ctrl-Space': () => void;
+  };
+}
+
+export function setupCodemirror(
+  options: Options,
+  item: CellDOMPlaceholder,
+  cell: IThebeCell,
+  cellEl: HTMLElement,
+  editorEl: HTMLElement,
+  setBusy: (id: string) => void,
+  clearBusy: (id: string) => void,
+) {
+  const { source: sourceEl } = item.placeholders;
+  const modeFromPage = sourceEl.getAttribute('data-language') || 'python';
+  const isReadOnlyFromPage = sourceEl.getAttribute('data-readonly');
+  console.debug(`thebe:setupCodemirror isReadOnly: ${isReadOnlyFromPage}`);
+
+  async function execute() {
+    console.debug(`thebe:codemirror:shift-enter execute`);
+    try {
+      setBusy(cell.id);
+      await cell.execute(cell.source);
+      clearBusy(cell.id);
+    } catch (error) {
+      cell.clearOnError(error);
+    }
+  }
+
+  const ref: { cm?: any } = { cm: undefined };
+
+  function codeCompletion() {
+    console.debug(`thebe:codemirror:codeCompletion`);
+    const code = ref.cm?.getValue();
+    const cursor = ref.cm?.getDoc().getCursor();
+    if (cell.session?.kernel) {
+      cell.session?.kernel
+        .requestComplete({
+          code,
+          cursor_pos: ref.cm?.getDoc().indexFromPos(cursor),
+        })
+        .then((value: ICompleteReplyMsg) => {
+          if (value.content.status === 'ok') {
+            const from = ref.cm?.getDoc().posFromIndex(value.content.cursor_start);
+            const to = ref.cm?.getDoc().posFromIndex(value.content.cursor_end);
+            ref.cm?.showHint({
+              container: editorEl,
+              hint: () => {
+                return {
+                  from: from,
+                  to: to,
+                  list: (value.content as { matches: string[] }).matches,
+                };
+              },
+            });
+          }
+        });
+    }
+  }
+
+  const defaultSettings: DefaultCodeMirrorConfig = {
+    theme: 'default',
+    mode: 'python',
+    readOnly: false,
+    autoRefresh: true,
+    lineNumbers: true,
+    styleActiveLine: true,
+    matchBrackets: true,
+  };
+
+  const configFromPage: PageCodeMirrorConfig = {
+    mode: modeFromPage,
+    readOnly: undefined,
+  };
+
+  if (isReadOnlyFromPage != null) {
+    // override settings using the cell attribute
+    configFromPage.readOnly = isReadOnlyFromPage == 'false' ? false : true;
+  }
+
+  const requiredSettings: RequiredCodeMirrorConfig = {
+    value: cell.source,
+    extraKeys: {
+      'Shift-Enter': execute,
+      'Ctrl-Space': codeCompletion,
+    },
+  };
+
+  const codeMirrorConfig = Object.assign(
+    {},
+    defaultSettings,
+    options.codeMirrorConfig ?? {},
+    configFromPage,
+    requiredSettings,
+  );
+  console.debug('thebe:setupCodemirror:codeMirrorConfig', codeMirrorConfig);
+
+  ref.cm = new CodeMirror(editorEl as HTMLElement, codeMirrorConfig);
+  console.debug('thebe:setupCodemirror:autoLoadMode mode for', modeFromPage);
+  CodeMirror.autoLoadMode(ref.cm, modeFromPage);
+
+  // All cells in the notebook automatically update their sources on change
+  ref?.cm?.on('change', () => {
+    const code = ref?.cm?.getValue();
+    cell.source = code;
+    ref?.cm?.refresh();
+  });
+
+  if (codeMirrorConfig.readOnly) {
+    ref.cm?.display.lineDiv.setAttribute('data-readonly', 'true');
+    editorEl.setAttribute('data-readonly', 'true');
+    cellEl.setAttribute('data-readonly', 'true');
+  }
+
+  ref.cm.refresh();
+
+  return ref.cm;
+}

--- a/packages/thebe/src/codemirror.ts
+++ b/packages/thebe/src/codemirror.ts
@@ -2,11 +2,12 @@ import CodeMirror from 'codemirror/lib/codemirror';
 import 'codemirror/lib/codemirror.css';
 import 'codemirror/mode/python/python.js';
 import 'codemirror/addon/hint/show-hint';
-import 'codemirror/addon/mode/loadMode';
 import 'codemirror/addon/display/autorefresh';
 import 'codemirror/theme/abcdef.css';
 import 'codemirror/theme/darcula.css';
 import 'codemirror/theme/idea.css';
+
+import { Mode } from '@jupyterlab/codemirror';
 
 import type { Options } from './options';
 import type { IThebeCell } from 'thebe-core';
@@ -129,9 +130,9 @@ export function setupCodemirror(
   );
   console.debug('thebe:setupCodemirror:codeMirrorConfig', codeMirrorConfig);
 
+  Mode.ensure(codeMirrorConfig.mode).then(() => ref.cm?.setOption('mode', codeMirrorConfig.mode));
   ref.cm = new CodeMirror(editorEl as HTMLElement, codeMirrorConfig);
-  console.debug('thebe:setupCodemirror:autoLoadMode mode for', modeFromPage);
-  CodeMirror.autoLoadMode(ref.cm, modeFromPage);
+  console.debug('thebe:setupCodemirror:autoLoadMode mode for', codeMirrorConfig.mode);
 
   // All cells in the notebook automatically update their sources on change
   ref?.cm?.on('change', () => {

--- a/packages/thebe/src/index.css
+++ b/packages/thebe/src/index.css
@@ -4,6 +4,11 @@
 @import './activate.css';
 @import './status.css';
 
+.CodeMirror {
+  height: auto;
+  border: 1px solid grey;
+}
+
 .thebelab-cell,
 .thebe-cell,
 .thebe-cell > div {
@@ -23,18 +28,6 @@
   padding-top: 0.5em;
   border-top: 1px solid #aaa;
 }
-/* 
-.CodeMirror {
-  height: auto;
-}
-
-.CodeMirror-scroll {
-  height: auto;
-}
-
-.CodeMirror.CodeMirror-focused {
-  background-color: white;
-} */
 
 /* no prompts */
 .jp-OutputPrompt {

--- a/packages/thebe/src/index.css
+++ b/packages/thebe/src/index.css
@@ -1,5 +1,5 @@
-@import '@jupyterlab/codemirror/style/base.css';
-@import 'codemirror/lib/codemirror.css';
+/* @import '@jupyterlab/codemirror/style/base.css';
+@import 'codemirror/lib/codemirror.css'; */
 @import 'thebe-core/dist/lib/thebe-core.css';
 @import './activate.css';
 @import './status.css';
@@ -23,7 +23,7 @@
   padding-top: 0.5em;
   border-top: 1px solid #aaa;
 }
-
+/* 
 .CodeMirror {
   height: auto;
 }
@@ -34,7 +34,7 @@
 
 .CodeMirror.CodeMirror-focused {
   background-color: white;
-}
+} */
 
 /* no prompts */
 .jp-OutputPrompt {
@@ -76,7 +76,7 @@
     -webkit-transform: rotate(360deg);
   }
 }
-
+/* 
 ul.CodeMirror-hints {
   position: absolute;
   z-index: 10;
@@ -112,4 +112,4 @@ li.CodeMirror-hint {
 li.CodeMirror-hint-active {
   background: #08f;
   color: white;
-}
+} */

--- a/packages/thebe/src/options.ts
+++ b/packages/thebe/src/options.ts
@@ -31,6 +31,11 @@ export interface ThebeOptions {
   codeMirrorConfig?: {
     theme?: string;
     readOnly?: boolean;
+    mode?: string;
+    autoRefresh?: boolean;
+    lineNumbers?: boolean;
+    styleActiveLine?: boolean;
+    matchBrackets?: boolean;
   };
 }
 

--- a/packages/thebe/src/render.ts
+++ b/packages/thebe/src/render.ts
@@ -3,6 +3,7 @@ import CodeMirror from 'codemirror/lib/codemirror';
 import 'codemirror/mode/python/python.js';
 import 'codemirror/addon/hint/show-hint';
 import 'codemirror/addon/mode/loadMode';
+import 'codemirror/addon/display/autorefresh';
 import type { IThebeCell, ThebeNotebook } from 'thebe-core';
 import type { Options } from './options';
 import { randomId } from './utils';
@@ -108,6 +109,7 @@ interface ExtendedCodemirrorConfig {
     'Shift-Enter': () => void;
     'Ctrl-Space': () => void;
   };
+  autoRefresh: boolean;
 }
 
 function setupCodemirror(
@@ -171,6 +173,7 @@ function setupCodemirror(
       'Shift-Enter': execute,
       'Ctrl-Space': codeCompletion,
     },
+    autoRefresh: true,
   };
 
   if (isReadOnly != null) {
@@ -193,20 +196,16 @@ function setupCodemirror(
   ref?.cm?.on('change', () => {
     const code = ref?.cm?.getValue();
     cell.source = code;
+    ref?.cm?.refresh();
   });
-
-  // TODO can we avoid this?
-  // this mode loading is not effective
-  // Mode.ensure(mode).then((spec) => {
-  //   console.debug('thebe:setupCodemirror:ensureModeSpec', spec);
-  //   ref.cm?.setOption('mode', mode);
-  // });
 
   if (codeMirrorConfig.readOnly) {
     ref.cm?.display.lineDiv.setAttribute('data-readonly', 'true');
     editorEl.setAttribute('data-readonly', 'true');
     cellEl.setAttribute('data-readonly', 'true');
   }
+
+  ref.cm.refresh();
 
   return ref.cm;
 }

--- a/packages/thebe/src/render.ts
+++ b/packages/thebe/src/render.ts
@@ -1,10 +1,11 @@
 import CodeMirror from 'codemirror/lib/codemirror';
-import 'codemirror/lib/codemirror.css';
+// import 'codemirror/lib/codemirror.css';
+import 'codemirror/mode/python/python.js';
 import 'codemirror/addon/hint/show-hint';
+import 'codemirror/addon/mode/loadMode';
 import type { IThebeCell, ThebeNotebook } from 'thebe-core';
 import type { Options } from './options';
 import { randomId } from './utils';
-import { Mode } from '@jupyterlab/codemirror';
 import type { ICompleteReplyMsg } from '@jupyterlab/services/lib/kernel/messages';
 
 export interface CellDOMPlaceholder {
@@ -178,13 +179,15 @@ function setupCodemirror(
   }
 
   const codeMirrorConfig = Object.assign(
-    { theme: 'default' },
+    { theme: 'default', lineNumbers: true, styleActiveLine: true, matchBrackets: true },
     options.codeMirrorConfig ?? {},
     requiredSettings,
   );
   console.debug('thebe:setupCodemirror:codeMirrorConfig', codeMirrorConfig);
 
   ref.cm = new CodeMirror(editorEl as HTMLElement, codeMirrorConfig);
+  console.debug('thebe:setupCodemirror:autoLoadMode mode for', mode);
+  CodeMirror.autoLoadMode(ref.cm, mode);
 
   // All cells in the notebook automatically update their sources on change
   ref?.cm?.on('change', () => {
@@ -193,7 +196,12 @@ function setupCodemirror(
   });
 
   // TODO can we avoid this?
-  Mode.ensure(mode).then(() => ref.cm?.setOption('mode', 'mode'));
+  // this mode loading is not effective
+  // Mode.ensure(mode).then((spec) => {
+  //   console.debug('thebe:setupCodemirror:ensureModeSpec', spec);
+  //   ref.cm?.setOption('mode', mode);
+  // });
+
   if (codeMirrorConfig.readOnly) {
     ref.cm?.display.lineDiv.setAttribute('data-readonly', 'true');
     editorEl.setAttribute('data-readonly', 'true');

--- a/packages/thebe/src/thebe.ts
+++ b/packages/thebe/src/thebe.ts
@@ -1,5 +1,4 @@
 import { defaultOutputSelector, defaultSelector, mergeOptions } from './options';
-import type { CellDOMPlaceholder } from './render';
 import { findCells, renderAllCells } from './render';
 import { stripPrompts, stripOutputPrompts } from './utils';
 import { KernelStatus } from './status';
@@ -13,6 +12,7 @@ import * as controls from '@jupyter-widgets/controls';
 import { output } from '@jupyter-widgets/jupyterlab-manager';
 import type { Options } from './options';
 import { makeConfiguration, setupNotebookFromBlocks, ThebeServer } from 'thebe-core';
+import type { CellDOMPlaceholder } from './types';
 
 if (typeof window !== 'undefined' && typeof window.define !== 'undefined') {
   window.define('@jupyter-widgets/base', base);

--- a/packages/thebe/src/types.ts
+++ b/packages/thebe/src/types.ts
@@ -12,6 +12,28 @@ import type { Options } from './options';
 import type { KernelStatus } from './status';
 import type { ThebeLiteGlobal } from 'thebe-lite';
 
+export interface CellDOMPlaceholder {
+  id: string;
+  placeholders: {
+    source: Element;
+    output?: Element;
+  };
+}
+
+export type CellDOMItem = CellDOMPlaceholder & {
+  ui: {
+    cell: Element;
+    editor: Element;
+    output?: Element;
+    buttons: {
+      run?: Element;
+      runAll?: Element;
+      restart?: Element;
+      restartAll?: Element;
+    };
+  };
+};
+
 export interface ThebeGlobal {
   mountStatusWidget: () => void;
   mountActivateWidget: () => void;


### PR DESCRIPTION
This PR is work towards fixing syntax highlighting, mode selection and theming which will impact on the following issues:

* [x] https://github.com/executablebooks/thebe/issues/460
* [x] https://github.com/executablebooks/thebe/issues/241
* [x] https://github.com/executablebooks/thebe/issues/256

Useful reference for theme changes: https://codemirror.net/5/demo/theme.html#darcula

We should also tackle this here: 
* [x] https://github.com/executablebooks/thebe/issues/223 
it's in theory a breaking change to API but no-one can be relying on these options anyway.