### PR TITLE
🪴external rendermime managment

### DIFF
--- a/apps/demo-core/src/app.ts
+++ b/apps/demo-core/src/app.ts
@@ -1,5 +1,6 @@
 import type { ThebeSession } from 'thebe-core';
 import {
+  makeRenderMimeRegistry,
   ThebeEvents,
   ThebeEventType,
   shortId,
@@ -216,7 +217,9 @@ class App {
       await this.server?.connectToJupyterServer();
     }
 
-    this.session = await this.server.startNewSession();
+    const rendermime = makeRenderMimeRegistry(this.server.config.mathjax);
+
+    this.session = await this.server.startNewSession(rendermime);
 
     this.notebook = ThebeNotebook.fromCodeBlocks(
       code[this.exampleType].map((source) => ({
@@ -224,6 +227,7 @@ class App {
         source,
       })),
       this.server.config,
+      rendermime,
     );
 
     if (this.session == null) console.error('could not start session');

--- a/apps/demo-core/static/index.html
+++ b/apps/demo-core/static/index.html
@@ -20,7 +20,7 @@
       src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.7/latest.js?config=TeX-MML-AM_CHTML"
     ></script>
     <script src="thebe-lite.min.js" type="text/javascript"></script>
-    <script src="demo.js" type="text/javascript"></script>
+    <script src="thebe-demo.js" type="text/javascript"></script>
     <link rel="stylesheet" href="demo.css" />
     <link rel="stylesheet" href="thebe-core.css" />
     <link

--- a/apps/demo-react/src/NotebookPage.tsx
+++ b/apps/demo-react/src/NotebookPage.tsx
@@ -1,12 +1,14 @@
-import { ThebeSessionProvider, useThebeServer } from 'thebe-react';
+import { ThebeSessionProvider, ThebeRenderMimeRegistryProvider, useThebeServer } from 'thebe-react';
 
 export function NotebookPage({ name, children }: React.PropsWithChildren<{ name: string }>) {
   const { ready } = useThebeServer();
 
   if (!ready) return null;
   return (
-    <ThebeSessionProvider start name={name}>
-      {children}
-    </ThebeSessionProvider>
+    <ThebeRenderMimeRegistryProvider>
+      <ThebeSessionProvider start name={name}>
+        {children}
+      </ThebeSessionProvider>
+    </ThebeRenderMimeRegistryProvider>
   );
 }

--- a/packages/core/src/cell.ts
+++ b/packages/core/src/cell.ts
@@ -71,7 +71,6 @@ class ThebeCell extends PassiveCellRenderer implements IThebeCell {
    * @param session
    */
   attachSession(session: ThebeSession) {
-    session.manager.addWidgetFactories(this.rendermime);
     this.session = session;
     this.events.triggerStatus({
       status: CellStatusEvent.attached,
@@ -85,7 +84,6 @@ class ThebeCell extends PassiveCellRenderer implements IThebeCell {
    *
    */
   detachSession() {
-    this.session?.manager.removeWidgetFactories(this.rendermime);
     this.session = undefined;
     this.events.triggerStatus({
       status: CellStatusEvent.detached,

--- a/packages/core/src/manager.ts
+++ b/packages/core/src/manager.ts
@@ -1,5 +1,4 @@
 import type { IRenderMimeRegistry } from '@jupyterlab/rendermime';
-import { RenderMimeRegistry, standardRendererFactories } from '@jupyterlab/rendermime';
 import type { IKernelConnection } from '@jupyterlab/services/lib/kernel/kernel';
 import type { Widget } from '@lumino/widgets';
 
@@ -26,34 +25,21 @@ export class ThebeManager extends KernelWidgetManager {
   id: string;
   _loader: RequireJsLoader;
 
-  constructor(kernel: IKernelConnection, rendermime?: IRenderMimeRegistry) {
-    const rm =
-      rendermime ??
-      new RenderMimeRegistry({
-        initialFactories: standardRendererFactories,
-      });
+  constructor(kernel: IKernelConnection, rendermime: IRenderMimeRegistry) {
+    super(kernel, rendermime);
 
+    this.id = shortId();
     /** ensure this registry always gets the widget renderer.
      * This is essential for cases where widgets are rendered heirarchically
      */
-    rm.addFactory(
-      {
-        safe: false,
-        mimeTypes: [WIDGET_MIMETYPE],
-        createRenderer: (options) => new WidgetRenderer(options, this as any),
-      },
-      1,
-    );
+    this.addWidgetFactories();
 
-    super(kernel, rm);
-
-    this.id = shortId();
     this._registerWidgets();
     this._loader = new RequireJsLoader();
   }
 
-  addWidgetFactories(rendermime: IRenderMimeRegistry) {
-    rendermime.addFactory(
+  addWidgetFactories() {
+    this.rendermime.addFactory(
       {
         safe: false,
         mimeTypes: [WIDGET_MIMETYPE],
@@ -63,8 +49,8 @@ export class ThebeManager extends KernelWidgetManager {
     );
   }
 
-  removeWidgetFactories(rendermime: IRenderMimeRegistry) {
-    rendermime.removeMimeType(WIDGET_MIMETYPE);
+  removeWidgetFactories() {
+    this.rendermime.removeMimeType(WIDGET_MIMETYPE);
   }
 
   /**

--- a/packages/core/src/passive.ts
+++ b/packages/core/src/passive.ts
@@ -1,5 +1,5 @@
 import type * as nbformat from '@jupyterlab/nbformat';
-import { getRenderMimeRegistry } from './rendermime';
+import { makeRenderMimeRegistry } from './rendermime';
 import { OutputArea, OutputAreaModel } from '@jupyterlab/outputarea';
 import type { IRenderMimeRegistry } from '@jupyterlab/rendermime';
 import type { IPassiveCell, MathjaxOptions } from './types';
@@ -49,7 +49,7 @@ class PassiveCellRenderer implements IPassiveCell {
 
   constructor(id: string, rendermime?: IRenderMimeRegistry, mathjax?: MathjaxOptions) {
     this.id = id;
-    this.rendermime = rendermime ?? getRenderMimeRegistry(mathjax ?? makeMathjaxOptions());
+    this.rendermime = rendermime ?? makeRenderMimeRegistry(mathjax ?? makeMathjaxOptions());
     this.model = new OutputAreaModel({ trusted: true });
     this.area = new OutputArea({
       model: this.model,

--- a/packages/core/src/rendermime.ts
+++ b/packages/core/src/rendermime.ts
@@ -55,7 +55,7 @@ export function getRenderers(mathjax: MathjaxOptions) {
   };
 }
 
-export function getRenderMimeRegistry(mathjax?: MathjaxOptions) {
+export function makeRenderMimeRegistry(mathjax?: MathjaxOptions) {
   const rendermime = new RenderMimeRegistry(getRenderers(mathjax ?? makeMathjaxOptions()));
   rendermime.addFactory(jsonRendererFactory, 10);
   return rendermime;

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -3,6 +3,7 @@ import { EventSubject, SessionStatusEvent } from './events';
 import { ThebeManager } from './manager';
 import type ThebeServer from './server';
 import { EventEmitter } from './emitter';
+import type { IRenderMimeRegistry } from '@jupyterlab/rendermime';
 
 class ThebeSession {
   readonly server: ThebeServer;
@@ -11,13 +12,17 @@ class ThebeSession {
   private connection: ISessionConnection;
   private events: EventEmitter;
 
-  constructor(server: ThebeServer, connection: ISessionConnection) {
+  constructor(
+    server: ThebeServer,
+    connection: ISessionConnection,
+    rendermime: IRenderMimeRegistry,
+  ) {
     this.server = server;
     this.connection = connection;
     this.events = new EventEmitter(this.connection.id, server.config, EventSubject.session, this);
 
     if (this.connection.kernel == null) throw Error('ThebeSession - kernel is null');
-    this.manager = new ThebeManager(this.connection.kernel);
+    this.manager = new ThebeManager(this.connection.kernel, rendermime);
 
     this.events.triggerStatus({
       status: SessionStatusEvent.ready,

--- a/packages/core/src/thebe/api.ts
+++ b/packages/core/src/thebe/api.ts
@@ -3,8 +3,11 @@ import type { CodeBlock } from '../notebook';
 import ThebeNotebook from '../notebook';
 import type { INotebookContent } from '@jupyterlab/nbformat';
 import type { Config } from '..';
-import { makeConfiguration, ThebeEvents } from '..';
+import { ThebeEvents } from '../events';
+import { makeConfiguration } from '../options';
+import { makeRenderMimeRegistry } from '../rendermime';
 import * as coreModule from '../index';
+import type { IRenderMimeRegistry } from '@jupyterlab/rendermime';
 
 export function connectToBinder(config: Config): ThebeServer {
   const server: ThebeServer = new ThebeServer(config);
@@ -35,21 +38,31 @@ export function makeServer(config: Config) {
   return new ThebeServer(config);
 }
 
-export function setupNotebookFromBlocks(blocks: CodeBlock[], config: Config) {
-  return ThebeNotebook.fromCodeBlocks(blocks, config);
+export function setupNotebookFromBlocks(
+  blocks: CodeBlock[],
+  config: Config,
+  rendermime: IRenderMimeRegistry,
+) {
+  return ThebeNotebook.fromCodeBlocks(blocks, config, rendermime);
 }
 
-export function setupNotebookFromIpynb(ipynb: INotebookContent, config: Config) {
-  return ThebeNotebook.fromIpynb(ipynb, config);
+export function setupNotebookFromIpynb(
+  ipynb: INotebookContent,
+  config: Config,
+  rendermime: IRenderMimeRegistry,
+) {
+  return ThebeNotebook.fromIpynb(ipynb, config, rendermime);
 }
 
 export function setupThebeCore() {
+  console.log(`thebe:api:setupThebeCore`, { coreModule });
   window.thebeCore = Object.assign(window.thebeCore ?? {}, {
     module: coreModule,
     api: {
       makeConfiguration,
       makeEvents,
       makeServer,
+      makeRenderMimeRegistry,
       connectToBinder,
       connectToJupyter,
       connectToJupyterLite,

--- a/packages/core/src/thebe/entrypoint.ts
+++ b/packages/core/src/thebe/entrypoint.ts
@@ -13,6 +13,7 @@ import type { ThebeEvents } from '../events';
 import type { ThebeLiteGlobal } from 'thebe-lite';
 import type * as coreModule from '../index';
 import type { INotebookContent } from '@jupyterlab/nbformat';
+import type { IRenderMimeRegistry } from '@jupyterlab/rendermime';
 import { setupThebeCore } from './api';
 
 /**
@@ -24,11 +25,20 @@ export interface JsApi {
   makeEvents: () => ThebeEvents;
   makeConfiguration: (options: Partial<CoreOptions>, events?: ThebeEvents) => Config;
   makeServer: (config: Config) => ThebeServer;
+  makeRenderMimeRegistry: (mathjax?: coreModule.MathjaxOptions | undefined) => IRenderMimeRegistry;
   connectToBinder: (config: Config) => ThebeServer;
   connectToJupyter: (config: Config) => ThebeServer;
   connectToJupyterLite: (config: Config) => ThebeServer;
-  setupNotebookFromBlocks: (blocks: CodeBlock[], config: Config) => ThebeNotebook;
-  setupNotebookFromIpynb: (ipynb: INotebookContent, config: Config) => ThebeNotebook;
+  setupNotebookFromBlocks: (
+    blocks: CodeBlock[],
+    config: Config,
+    rendermime: IRenderMimeRegistry,
+  ) => ThebeNotebook;
+  setupNotebookFromIpynb: (
+    ipynb: INotebookContent,
+    config: Config,
+    rendermime: IRenderMimeRegistry,
+  ) => ThebeNotebook;
 }
 
 export type ThebeCore = typeof coreModule;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -9,6 +9,7 @@ export type JsonObject = Record<string, any>;
 export type SessionIModel = Session.IModel;
 export type KernelISpecModels = KernelSpecAPI.ISpecModels;
 export type KernelISpecModel = KernelSpecAPI.ISpecModel;
+export type { IRenderMimeRegistry } from '@jupyterlab/rendermime';
 
 export interface ServerInfo {
   id: string;

--- a/packages/react/src/ThebeRenderMimeRegistryProvider.tsx
+++ b/packages/react/src/ThebeRenderMimeRegistryProvider.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import type { IRenderMimeRegistry } from 'thebe-core';
+import { useThebeCore } from './ThebeCoreProvider';
+import { useThebeConfig } from './ThebeServerProvider';
+
+const RenderMimeRegistryContext = React.createContext<
+  { rendermime: IRenderMimeRegistry } | undefined
+>(undefined);
+
+/* future: could allow for renderer configuration here */
+export function ThebeRenderMimeRegistryProvider({ children }: React.PropsWithChildren) {
+  const { core } = useThebeCore();
+  const { config } = useThebeConfig();
+  const rendermime = React.useMemo(
+    () => core?.makeRenderMimeRegistry(config?.mathjax) as IRenderMimeRegistry,
+    [core, config],
+  );
+
+  return (
+    <RenderMimeRegistryContext.Provider value={{ rendermime }}>
+      {children}
+    </RenderMimeRegistryContext.Provider>
+  );
+}
+
+export function useRenderMimeRegistry() {
+  const context = React.useContext(RenderMimeRegistryContext);
+  if (context === undefined) {
+    throw new Error('useRenderMimeRegistry must be used within a ThebeRenderMimeRegistry');
+  }
+  return context.rendermime;
+}

--- a/packages/react/src/ThebeSessionProvider.tsx
+++ b/packages/react/src/ThebeSessionProvider.tsx
@@ -1,6 +1,7 @@
 import React, { useContext, useEffect, useState } from 'react';
 import type { ThebeSession } from 'thebe-core';
 import { useThebeServer } from './ThebeServerProvider';
+import { useRenderMimeRegistry } from './ThebeRenderMimeRegistryProvider';
 
 interface ThebeSessionContextData {
   name: string;
@@ -27,6 +28,7 @@ export function ThebeSessionProvider({
   shutdownOnUnmount?: boolean;
 }>) {
   const { config, server, ready: serverReady } = useThebeServer();
+  const rendermime = useRenderMimeRegistry();
 
   const [starting, setStarting] = useState(false);
   const [session, setSession] = useState<ThebeSession | undefined>();
@@ -36,7 +38,7 @@ export function ThebeSessionProvider({
   const startSession = () => {
     setStarting(true);
     server
-      ?.startNewSession({ ...config?.kernels, name, path: name })
+      ?.startNewSession(rendermime, { ...config?.kernels, name, path: name })
       .then((sesh: ThebeSession | null) => {
         setStarting(false);
         if (sesh == null) {

--- a/packages/react/src/hooks/notebook.ts
+++ b/packages/react/src/hooks/notebook.ts
@@ -4,6 +4,8 @@ import { useThebeConfig } from '../ThebeServerProvider';
 import { useThebeCore } from '../ThebeCoreProvider';
 import type { INotebookContent } from '@jupyterlab/nbformat';
 import { useThebeSession } from '../ThebeSessionProvider';
+import { useRenderMimeRegistry } from '../ThebeRenderMimeRegistryProvider';
+import { render } from 'react-dom';
 
 export interface NotebookExecuteOptions {
   stopOnError?: boolean;
@@ -42,6 +44,7 @@ export function useNotebookBase() {
    */
   useEffect(() => {
     if (!notebook || !session || !sessionReady) return;
+    console.debug(`thebe-react: attaching notebook to session`, { notebook, session });
     notebook.attachSession(session);
     setSessionAttached(true);
   }, [notebook, session, sessionReady]);
@@ -118,6 +121,7 @@ export function useNotebook(
 ) {
   const { core } = useThebeCore();
   const { config } = useThebeConfig();
+  const rendermime = useRenderMimeRegistry();
   const [loading, setLoading] = useState<boolean>(false);
 
   const {
@@ -148,7 +152,7 @@ export function useNotebook(
     setLoading(true);
     fetchNotebook(name)
       .then((ipynb) => {
-        return core?.ThebeNotebook.fromIpynb(ipynb, config);
+        return core?.ThebeNotebook.fromIpynb(ipynb, config, rendermime);
       })
       .then((nb: ThebeNotebook) => {
         const cells = opts?.refsForWidgetsOnly ? nb?.widgets ?? [] : nb?.cells ?? [];
@@ -193,6 +197,7 @@ export function useNotebook(
 export function useNotebookFromSource(sourceCode: string[], opts = { refsForWidgetsOnly: true }) {
   const { core } = useThebeCore();
   const { config } = useThebeConfig();
+  const rendermime = useRenderMimeRegistry();
   const [loading, setLoading] = useState(false);
   const {
     ready,
@@ -216,6 +221,7 @@ export function useNotebookFromSource(sourceCode: string[], opts = { refsForWidg
     const nb = core.ThebeNotebook.fromCodeBlocks(
       sourceCode.map((source) => ({ id: core?.shortId(), source })),
       config,
+      rendermime,
     );
     const cells = opts?.refsForWidgetsOnly ? nb?.widgets ?? [] : nb?.cells ?? [];
     setRefs(
@@ -255,6 +261,7 @@ export function useNotebookFromSource(sourceCode: string[], opts = { refsForWidg
 export function useNotebookfromSourceLegacy(sourceCode: string[]) {
   const { core } = useThebeCore();
   const { config } = useThebeConfig();
+  const rendermime = useRenderMimeRegistry();
 
   const [busy, setBusy] = useState<boolean>(false);
   const [notebook, setNotebook] = useState<ThebeNotebook | undefined>();
@@ -271,6 +278,7 @@ export function useNotebookfromSourceLegacy(sourceCode: string[]) {
       core.ThebeNotebook.fromCodeBlocks(
         sourceCode.map((source) => ({ id: core?.shortId(), source })),
         config,
+        rendermime,
       ),
     );
   }, [core, notebook]);

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -2,4 +2,5 @@ export * from './OutputAreaByRef';
 export * from './ThebeCoreProvider';
 export * from './ThebeServerProvider';
 export * from './ThebeSessionProvider';
+export * from './ThebeRenderMimeRegistryProvider';
 export * from './hooks';

--- a/packages/thebe/src/thebe.ts
+++ b/packages/thebe/src/thebe.ts
@@ -11,7 +11,12 @@ import * as base from '@jupyter-widgets/base';
 import * as controls from '@jupyter-widgets/controls';
 import { output } from '@jupyter-widgets/jupyterlab-manager';
 import type { Options } from './options';
-import { makeConfiguration, setupNotebookFromBlocks, ThebeServer } from 'thebe-core';
+import {
+  makeConfiguration,
+  makeRenderMimeRegistry,
+  setupNotebookFromBlocks,
+  ThebeServer,
+} from 'thebe-core';
 import type { CellDOMPlaceholder } from './types';
 
 if (typeof window !== 'undefined' && typeof window.define !== 'undefined') {
@@ -70,8 +75,9 @@ export async function bootstrap(opts: Partial<Options> = {}) {
   });
 
   const config = makeConfiguration(options, window.thebe.events);
+  const rendermime = makeRenderMimeRegistry(config.mathjax);
 
-  const notebook = setupNotebookFromBlocks(codeWithIds, config);
+  const notebook = setupNotebookFromBlocks(codeWithIds, config, rendermime);
   window.thebe.notebook = notebook;
 
   renderAllCells(options, notebook, items);
@@ -100,7 +106,7 @@ export async function bootstrap(opts: Partial<Options> = {}) {
 
   await server.ready;
 
-  const session = await server.startNewSession();
+  const session = await server.startNewSession(rendermime);
   if (session != null) notebook.attachSession(session);
 
   window.thebe.session = session ?? undefined;

--- a/turbo.json
+++ b/turbo.json
@@ -26,11 +26,11 @@
       "outputs": ["dist/**"]
     },
     "demo-core#build": {
-      "dependsOn": ["thebe-core#build", "thebe-lite#build", "thebe#build"],
+      "dependsOn": ["thebe-core#build", "thebe-lite#build"],
       "outputs": ["dist/**"]
     },
     "demo-react#build": {
-      "dependsOn": ["thebe-core#build", "thebe-lite#build", "thebe#build"],
+      "dependsOn": ["thebe-core#build", "thebe-lite#build", "thebe-react#build"],
       "outputs": ["build/**"]
     },
     "demo": {


### PR DESCRIPTION
in #630 I was discussing how to improve the current very buggy rendermime creation. I pushed though on option (3) [making rendermime registry creation an explicit part of the API] in this PR, and...

Things are immediately much better, specific improvements are:

* much easier to reason about the expected ipywidgets behaviour
* some confusing addWidgetRenderer calls in notebooks have been removed
* the ThebeManager implementation is now just simple without the bizzare behaviour of adding widgets to some other rendermime.
* the only place where a rendermime registry is completed is now in the `PassiveCellRenderer` which feels right as that class is intended for standalone usage on static content.

So this is a keeper 🤘

