### PR TITLE
🆙 upgrade to `pyodide-kernel@0.0.8`

### DIFF
--- a/.changeset/nice-brooms-fly.md
+++ b/.changeset/nice-brooms-fly.md
@@ -1,0 +1,8 @@
+---
+'demo-core': patch
+'thebe-react': patch
+'thebe-lite': patch
+'demo-simple': patch
+---
+
+Upgraded default `pyodide-kernel` to `0.0.8`

--- a/apps/demo-core/package.json
+++ b/apps/demo-core/package.json
@@ -8,10 +8,10 @@
   "scripts": {
     "clean": "rm -rf dist",
     "copy:lite": "mkdir -p dist; cp -R ../../packages/lite/dist/lib/ dist",
-    "copy:core-css": "cp ../../packages/core/dist/lib/thebe-core.css static/thebe-core.css",
+    "copy:core-css": "cp ../../packages/core/dist/lib/thebe-core.css dist/thebe-core.css",
     "build": "npm run copy:lite; webpack --config webpack.dev.js",
     "demo": "npm run build",
-    "start": "npm run copy:lite; npm run copy:core-css; webpack serve --open --config webpack.dev.js",
+    "start": "npm run build; npm run copy:core-css; webpack serve --open --config webpack.dev.js",
     "watch": "npm run start"
   },
   "keywords": [

--- a/apps/simple/static/index.html
+++ b/apps/simple/static/index.html
@@ -19,6 +19,18 @@
         }
       }
     </script>
+    <script id="jupyter-config-data" type="application/json">
+      {
+        "litePluginSettings": {
+          "@jupyterlite/pyodide-kernel-extension:kernel": {
+            "pipliteUrls": ["https://unpkg.com/@jupyterlite/pyodide-kernel@0.0.8/pypi/all.json"],
+            "pipliteWheelUrl": "https://unpkg.com/@jupyterlite/pyodide-kernel@0.0.8/pypi/piplite-0.0.8-py3-none-any.whl"
+          }
+        },
+        "enableMemoryStorage": true,
+        "settingsStorageDrivers": ["memoryStorageDriver"]
+      }
+    </script>
     <!-- this following is the thebe entrypoint script -->
     <script src="thebe-lite.min.js"></script>
     <script src="index.js"></script>

--- a/apps/simple/static/ipywidgets-lite.html
+++ b/apps/simple/static/ipywidgets-lite.html
@@ -15,8 +15,8 @@
       {
         "litePluginSettings": {
           "@jupyterlite/pyodide-kernel-extension:kernel": {
-            "pipliteUrls": ["https://unpkg.com/@jupyterlite/pyodide-kernel@0.0.7/pypi/all.json"],
-            "pipliteWheelUrl": "https://unpkg.com/@jupyterlite/pyodide-kernel@0.0.7/pypi/piplite-0.0.7-py3-none-any.whl"
+            "pipliteUrls": ["https://unpkg.com/@jupyterlite/pyodide-kernel@0.0.8/pypi/all.json"],
+            "pipliteWheelUrl": "https://unpkg.com/@jupyterlite/pyodide-kernel@0.0.8/pypi/piplite-0.0.8-py3-none-any.whl"
           }
         },
         "enableMemoryStorage": true,

--- a/apps/simple/static/lite.html
+++ b/apps/simple/static/lite.html
@@ -15,8 +15,8 @@
       {
         "litePluginSettings": {
           "@jupyterlite/pyodide-kernel-extension:kernel": {
-            "pipliteUrls": ["https://unpkg.com/@jupyterlite/pyodide-kernel@0.0.7/pypi/all.json"],
-            "pipliteWheelUrl": "https://unpkg.com/@jupyterlite/pyodide-kernel@0.0.7/pypi/piplite-0.0.7-py3-none-any.whl"
+            "pipliteUrls": ["https://unpkg.com/@jupyterlite/pyodide-kernel@0.0.8/pypi/all.json"],
+            "pipliteWheelUrl": "https://unpkg.com/@jupyterlite/pyodide-kernel@0.0.8/pypi/piplite-0.0.8-py3-none-any.whl"
           }
         },
         "enableMemoryStorage": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -6240,9 +6240,9 @@
       }
     },
     "node_modules/@jupyterlite/pyodide-kernel": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/@jupyterlite/pyodide-kernel/-/pyodide-kernel-0.0.7.tgz",
-      "integrity": "sha512-7IK6VD+xqzbwYZQpOLjwAeajSm5O2XW2DNC7+pUhMRvOPzXcgRQp+lbE9esCAOLtyI+OHkb/04YV8nFzANdKfQ==",
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@jupyterlite/pyodide-kernel/-/pyodide-kernel-0.0.8.tgz",
+      "integrity": "sha512-SoRa+b+1sb5nu/To8zp8BehAD+76OaPJkBb7KpeGyTbbcXSG89c0P/2Ny7rLWlgjCEE81m/PVTh5rlj2J7CFFQ==",
       "dependencies": {
         "@jupyterlite/contents": "^0.1.0-beta.18",
         "@jupyterlite/kernel": "^0.1.0-beta.18",
@@ -6250,14 +6250,14 @@
       }
     },
     "node_modules/@jupyterlite/pyodide-kernel-extension": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/@jupyterlite/pyodide-kernel-extension/-/pyodide-kernel-extension-0.0.7.tgz",
-      "integrity": "sha512-b4xNnVSAsghLn7LF7opchFwhRxiI4E3llJzqFgNUcGiEMNsN8l0aZ1Qiy1RShDkuPFbJmkGttXa1S7I9svjO+w==",
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@jupyterlite/pyodide-kernel-extension/-/pyodide-kernel-extension-0.0.8.tgz",
+      "integrity": "sha512-dsTI011Nn+76ClC9eST+XSK/d5ZSaVuoFJkIhVDA6DTE15ouKfjbZOkkatLdjtKYa3Bi1B/aVmNpokiB0cl2nw==",
       "dependencies": {
         "@jupyterlab/coreutils": "^5.5.2",
         "@jupyterlite/contents": "^0.1.0-beta.18",
         "@jupyterlite/kernel": "^0.1.0-beta.18",
-        "@jupyterlite/pyodide-kernel": "^0.0.7",
+        "@jupyterlite/pyodide-kernel": "^0.0.8",
         "@jupyterlite/server": "^0.1.0-beta.18"
       }
     },
@@ -33351,18 +33351,105 @@
       "license": "MIT",
       "dependencies": {
         "@jupyterlab/coreutils": "^5.6.3",
-        "@jupyterlite/pyodide-kernel": "0.0.7",
-        "@jupyterlite/pyodide-kernel-extension": "0.0.7",
+        "@jupyterlite/pyodide-kernel": "0.0.8",
+        "@jupyterlite/pyodide-kernel-extension": "0.0.8",
         "@jupyterlite/server": "0.1.0",
         "@jupyterlite/server-extension": "0.1.0",
         "hook-shell-script-webpack-plugin": "^0.1.4"
       },
       "devDependencies": {
+        "copy-webpack-plugin": "^11.0.0",
         "current-script-polyfill": "^1.0.0",
         "ignore-emit-webpack-plugin": "^2.0.6",
         "no-emit-webpack-plugin": "^4.0.1",
         "npm-run-all": "^4.1.5",
         "webpack": "^5.74.0"
+      }
+    },
+    "packages/lite/node_modules/ajv-keywords": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
+      "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
+      "dev": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3"
+      },
+      "peerDependencies": {
+        "ajv": "^8.8.2"
+      }
+    },
+    "packages/lite/node_modules/copy-webpack-plugin": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-11.0.0.tgz",
+      "integrity": "sha512-fX2MWpamkW0hZxMEg0+mYnA40LTosOSa5TqZ9GYIBzyJa9C3QUaMPSE2xAi/buNr8u89SfD9wHSQVBzrRa/SOQ==",
+      "dev": true,
+      "dependencies": {
+        "fast-glob": "^3.2.11",
+        "glob-parent": "^6.0.1",
+        "globby": "^13.1.1",
+        "normalize-path": "^3.0.0",
+        "schema-utils": "^4.0.0",
+        "serialize-javascript": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 14.15.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "webpack": "^5.1.0"
+      }
+    },
+    "packages/lite/node_modules/globby": {
+      "version": "13.1.4",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-13.1.4.tgz",
+      "integrity": "sha512-iui/IiiW+QrJ1X1hKH5qwlMQyv34wJAYwH1vrf8b9kBA4sNiif3gKsMHa+BrdnOpEudWjpotfa7LrTzB1ERS/g==",
+      "dev": true,
+      "dependencies": {
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.2.11",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
+        "slash": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/lite/node_modules/schema-utils": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.0.1.tgz",
+      "integrity": "sha512-lELhBAAly9NowEsX0yZBlw9ahZG+sK/1RJ21EpzdYHKEs13Vku3LJ+MIPhh4sMs0oCCeufZQEQbMekiA4vuVIQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/json-schema": "^7.0.9",
+        "ajv": "^8.9.0",
+        "ajv-formats": "^2.1.1",
+        "ajv-keywords": "^5.1.0"
+      },
+      "engines": {
+        "node": ">= 12.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    },
+    "packages/lite/node_modules/slash": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-4.0.0.tgz",
+      "integrity": "sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "packages/react": {
@@ -38469,9 +38556,9 @@
       }
     },
     "@jupyterlite/pyodide-kernel": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/@jupyterlite/pyodide-kernel/-/pyodide-kernel-0.0.7.tgz",
-      "integrity": "sha512-7IK6VD+xqzbwYZQpOLjwAeajSm5O2XW2DNC7+pUhMRvOPzXcgRQp+lbE9esCAOLtyI+OHkb/04YV8nFzANdKfQ==",
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@jupyterlite/pyodide-kernel/-/pyodide-kernel-0.0.8.tgz",
+      "integrity": "sha512-SoRa+b+1sb5nu/To8zp8BehAD+76OaPJkBb7KpeGyTbbcXSG89c0P/2Ny7rLWlgjCEE81m/PVTh5rlj2J7CFFQ==",
       "requires": {
         "@jupyterlite/contents": "^0.1.0-beta.18",
         "@jupyterlite/kernel": "^0.1.0-beta.18",
@@ -38479,14 +38566,14 @@
       }
     },
     "@jupyterlite/pyodide-kernel-extension": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/@jupyterlite/pyodide-kernel-extension/-/pyodide-kernel-extension-0.0.7.tgz",
-      "integrity": "sha512-b4xNnVSAsghLn7LF7opchFwhRxiI4E3llJzqFgNUcGiEMNsN8l0aZ1Qiy1RShDkuPFbJmkGttXa1S7I9svjO+w==",
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@jupyterlite/pyodide-kernel-extension/-/pyodide-kernel-extension-0.0.8.tgz",
+      "integrity": "sha512-dsTI011Nn+76ClC9eST+XSK/d5ZSaVuoFJkIhVDA6DTE15ouKfjbZOkkatLdjtKYa3Bi1B/aVmNpokiB0cl2nw==",
       "requires": {
         "@jupyterlab/coreutils": "^5.5.2",
         "@jupyterlite/contents": "^0.1.0-beta.18",
         "@jupyterlite/kernel": "^0.1.0-beta.18",
-        "@jupyterlite/pyodide-kernel": "^0.0.7",
+        "@jupyterlite/pyodide-kernel": "^0.0.8",
         "@jupyterlite/server": "^0.1.0-beta.18"
       }
     },
@@ -57026,16 +57113,73 @@
       "version": "file:packages/lite",
       "requires": {
         "@jupyterlab/coreutils": "^5.6.3",
-        "@jupyterlite/pyodide-kernel": "0.0.7",
-        "@jupyterlite/pyodide-kernel-extension": "0.0.7",
+        "@jupyterlite/pyodide-kernel": "0.0.8",
+        "@jupyterlite/pyodide-kernel-extension": "0.0.8",
         "@jupyterlite/server": "0.1.0",
         "@jupyterlite/server-extension": "0.1.0",
+        "copy-webpack-plugin": "*",
         "current-script-polyfill": "^1.0.0",
         "hook-shell-script-webpack-plugin": "^0.1.4",
         "ignore-emit-webpack-plugin": "^2.0.6",
         "no-emit-webpack-plugin": "^4.0.1",
         "npm-run-all": "^4.1.5",
         "webpack": "^5.74.0"
+      },
+      "dependencies": {
+        "ajv-keywords": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
+          "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^3.1.3"
+          }
+        },
+        "copy-webpack-plugin": {
+          "version": "11.0.0",
+          "resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-11.0.0.tgz",
+          "integrity": "sha512-fX2MWpamkW0hZxMEg0+mYnA40LTosOSa5TqZ9GYIBzyJa9C3QUaMPSE2xAi/buNr8u89SfD9wHSQVBzrRa/SOQ==",
+          "dev": true,
+          "requires": {
+            "fast-glob": "^3.2.11",
+            "glob-parent": "^6.0.1",
+            "globby": "^13.1.1",
+            "normalize-path": "^3.0.0",
+            "schema-utils": "^4.0.0",
+            "serialize-javascript": "^6.0.0"
+          }
+        },
+        "globby": {
+          "version": "13.1.4",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-13.1.4.tgz",
+          "integrity": "sha512-iui/IiiW+QrJ1X1hKH5qwlMQyv34wJAYwH1vrf8b9kBA4sNiif3gKsMHa+BrdnOpEudWjpotfa7LrTzB1ERS/g==",
+          "dev": true,
+          "requires": {
+            "dir-glob": "^3.0.1",
+            "fast-glob": "^3.2.11",
+            "ignore": "^5.2.0",
+            "merge2": "^1.4.1",
+            "slash": "^4.0.0"
+          }
+        },
+        "schema-utils": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.0.1.tgz",
+          "integrity": "sha512-lELhBAAly9NowEsX0yZBlw9ahZG+sK/1RJ21EpzdYHKEs13Vku3LJ+MIPhh4sMs0oCCeufZQEQbMekiA4vuVIQ==",
+          "dev": true,
+          "requires": {
+            "@types/json-schema": "^7.0.9",
+            "ajv": "^8.9.0",
+            "ajv-formats": "^2.1.1",
+            "ajv-keywords": "^5.1.0"
+          }
+        },
+        "slash": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/slash/-/slash-4.0.0.tgz",
+          "integrity": "sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==",
+          "dev": true
+        }
       }
     },
     "thebe-react": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -57117,7 +57117,7 @@
         "@jupyterlite/pyodide-kernel-extension": "0.0.8",
         "@jupyterlite/server": "0.1.0",
         "@jupyterlite/server-extension": "0.1.0",
-        "copy-webpack-plugin": "*",
+        "copy-webpack-plugin": "^11.0.0",
         "current-script-polyfill": "^1.0.0",
         "hook-shell-script-webpack-plugin": "^0.1.4",
         "ignore-emit-webpack-plugin": "^2.0.6",

--- a/packages/lite/package.json
+++ b/packages/lite/package.json
@@ -41,13 +41,14 @@
   "homepage": "https://github.com/executablebooks/thebe#readme",
   "dependencies": {
     "@jupyterlab/coreutils": "^5.6.3",
-    "@jupyterlite/pyodide-kernel": "0.0.7",
-    "@jupyterlite/pyodide-kernel-extension": "0.0.7",
+    "@jupyterlite/pyodide-kernel": "0.0.8",
+    "@jupyterlite/pyodide-kernel-extension": "0.0.8",
     "@jupyterlite/server": "0.1.0",
     "@jupyterlite/server-extension": "0.1.0",
     "hook-shell-script-webpack-plugin": "^0.1.4"
   },
   "devDependencies": {
+    "copy-webpack-plugin": "^11.0.0",
     "current-script-polyfill": "^1.0.0",
     "ignore-emit-webpack-plugin": "^2.0.6",
     "no-emit-webpack-plugin": "^4.0.1",

--- a/packages/lite/webpack.config.cjs
+++ b/packages/lite/webpack.config.cjs
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 const path = require('path');
 const webpack = require('webpack');
+const CopyWebpackPlugin = require('copy-webpack-plugin');
 const { DefinePlugin, NormalModuleReplacementPlugin } = require('webpack');
 const HookShellScriptPlugin = require('hook-shell-script-webpack-plugin');
 
@@ -26,6 +27,15 @@ module.exports = {
     }),
     new HookShellScriptPlugin({
       afterEmit: ['node bin/stubContentsApi.js'],
+    }),
+    new CopyWebpackPlugin({
+      patterns: [
+        {
+          from: '../pypi/*.whl',
+          to: 'pypi',
+          context: path.dirname(require.resolve('@jupyterlite/pyodide-kernel')),
+        },
+      ],
     }),
   ],
   output: {

--- a/packages/react/src/ThebeServerProvider.tsx
+++ b/packages/react/src/ThebeServerProvider.tsx
@@ -72,9 +72,9 @@ export function ThebeServerProvider({
       server.connectToJupyterLiteServer({
         litePluginSettings: {
           '@jupyterlite/pyodide-kernel-extension:kernel': {
-            pipliteUrls: ['https://unpkg.com/@jupyterlite/pyodide-kernel@0.0.7/pypi/all.json'],
+            pipliteUrls: ['https://unpkg.com/@jupyterlite/pyodide-kernel@0.0.8/pypi/all.json'],
             pipliteWheelUrl:
-              'https://unpkg.com/@jupyterlite/pyodide-kernel@0.0.7/pypi/piplite-0.0.7-py3-none-any.whl',
+              'https://unpkg.com/@jupyterlite/pyodide-kernel@0.0.8/pypi/piplite-0.0.8-py3-none-any.whl',
           },
         },
       });


### PR DESCRIPTION
Because this came out  recently. Note that upgrading here really only means two things:

* We bump the version in our dependency list so that the right wheels get bundled into the `dist` folder for convenience
* We update the demos and `thebe-react` to use the CDN urls for the latest version

Beyond that the actual version of the `pyodide-kernel` is completely configurable at runtime, provided is maintains compatibility with the `JuypetrLiteServer` version in use.

(Note: this is something that can be improved and documented)