### PR TITLE
🐛 Show error when thebe fails to load

### DIFF
--- a/packages/react/src/ThebeCoreProvider.tsx
+++ b/packages/react/src/ThebeCoreProvider.tsx
@@ -28,9 +28,9 @@ export function ThebeCoreProvider({
         setCore(thebeCore);
         setLoading(false);
       })
-      .catch(({ reason }) => {
-        console.debug(`thebe-core load failed ${reason}`);
-        setError(reason);
+      .catch(({ message }) => {
+        console.debug(`thebe-core load failed ${message}`);
+        setError(message);
         setLoading(false);
       });
   }, [startLoad]);


### PR DESCRIPTION
This now shows an error, reason is not defined!

![image](https://github.com/executablebooks/thebe/assets/913249/054d2bfb-9434-45db-98ba-012dbc0bab53)
