### PR TITLE
make cells more stateful

### DIFF
--- a/.changeset/great-vans-flow.md
+++ b/.changeset/great-vans-flow.md
@@ -1,0 +1,5 @@
+---
+'thebe-core': patch
+---
+
+Fix to how initial outputs re read from the DOM, expose executionCount from the kernel, add caching of notebooks and reset functionality on cells and the notebook.

--- a/packages/core/src/cell.ts
+++ b/packages/core/src/cell.ts
@@ -12,6 +12,7 @@ class ThebeCell extends PassiveCellRenderer implements IThebeCell {
   source: string;
   metadata: JsonObject;
   session?: ThebeSession;
+  executionCount: number | null;
   readonly notebookId: string;
   protected busy: boolean;
   protected events: EventEmitter;
@@ -30,6 +31,7 @@ class ThebeCell extends PassiveCellRenderer implements IThebeCell {
     this.source = source;
     this.metadata = metadata;
     this.busy = false;
+    this.executionCount = null;
     console.debug('thebe:cell constructor', this);
   }
 
@@ -131,7 +133,8 @@ class ThebeCell extends PassiveCellRenderer implements IThebeCell {
       this.area.future = this.session.kernel.requestExecute({ code });
 
       // TODO consider how to enable execution without the await here
-      await this.area.future.done;
+      const reply = await this.area.future.done;
+      this.executionCount = reply.content.execution_count;
 
       let executeErrors: IError[] | undefined;
       for (let i = 0; i < this.model.length; i++) {

--- a/packages/core/src/cell.ts
+++ b/packages/core/src/cell.ts
@@ -5,7 +5,7 @@ import type { IRenderMimeRegistry } from '@jupyterlab/rendermime';
 import type { Config } from './config';
 import { CellStatusEvent, ErrorStatusEvent, errorToMessage, EventSubject } from './events';
 import { EventEmitter } from './emitter';
-import type { ICodeCell, IError } from '@jupyterlab/nbformat';
+import type { ICodeCell, IError, IOutput } from '@jupyterlab/nbformat';
 import { ensureString, shortId } from './utils';
 
 class ThebeCell extends PassiveCellRenderer implements IThebeCell {
@@ -13,6 +13,7 @@ class ThebeCell extends PassiveCellRenderer implements IThebeCell {
   metadata: JsonObject;
   session?: ThebeSession;
   executionCount: number | null;
+  protected initialOutputs: IOutput[];
   readonly notebookId: string;
   protected busy: boolean;
   protected events: EventEmitter;
@@ -32,6 +33,7 @@ class ThebeCell extends PassiveCellRenderer implements IThebeCell {
     this.metadata = metadata;
     this.busy = false;
     this.executionCount = null;
+    this.initialOutputs = [];
     console.debug('thebe:cell constructor', this);
   }
 
@@ -109,6 +111,38 @@ class ThebeCell extends PassiveCellRenderer implements IThebeCell {
       status: CellStatusEvent.idle,
       message: 'Completed',
     });
+  }
+
+  /**
+   * reset the DOM representation of the cell to the initial state
+   * along with the execution count
+   *
+   * @param hideWidgets boolean - if true, hide widgets
+   */
+  initOutputs(initialOutputs: IOutput[], hideWidgets?: boolean) {
+    this.initialOutputs = initialOutputs;
+    this.render(initialOutputs, hideWidgets);
+    this.executionCount = null;
+  }
+
+  /**
+   * reset the DOM representation of the cell to the initial state
+   * along with the execution count
+   *
+   * @param hideWidgets boolean - if true, hide widgets
+   */
+  reset(hideWidgets?: boolean) {
+    this.render(this.initialOutputs, hideWidgets);
+    this.executionCount = null;
+  }
+
+  /**
+   * refresh the DOM representation of the cell with the latest outputs
+   *
+   * @param hideWidgets boolean - if true, hide widgets
+   */
+  refresh(hideWidgets?: boolean) {
+    this.render(this.outputs, hideWidgets);
   }
 
   /**

--- a/packages/core/src/cell_noexec.ts
+++ b/packages/core/src/cell_noexec.ts
@@ -63,6 +63,18 @@ export default class NonExecutableCell extends PassiveCellRenderer implements IT
     // no-op
   }
 
+  initOutputs(initialOutputs: IOutput[], hideWidgets?: boolean) {
+    // no-op
+  }
+
+  reset(hideWidgets?: boolean) {
+    // no-op
+  }
+
+  refresh(hideWidgets?: boolean) {
+    // no-op
+  }
+
   attachToDOM(el?: HTMLElement) {
     // could potentially allow for markdown rendering here
   }

--- a/packages/core/src/cell_noexec.ts
+++ b/packages/core/src/cell_noexec.ts
@@ -51,6 +51,10 @@ export default class NonExecutableCell extends PassiveCellRenderer implements IT
     return false;
   }
 
+  get executionCount(): number | null {
+    return null;
+  }
+
   setAsBusy(): void {
     // no-op
   }

--- a/packages/core/src/notebook.ts
+++ b/packages/core/src/notebook.ts
@@ -75,6 +75,15 @@ class ThebeNotebook {
     return this.cells[this.cells.length - 1];
   }
 
+  /**
+   * reset the notebook to its initial state by resetting each cell
+   *
+   * @param hideWidgets boolean
+   */
+  reset(hideWidgets?: boolean) {
+    this.cells.forEach((cell) => cell.reset(hideWidgets));
+  }
+
   numCells() {
     return this.cells?.length ?? 0;
   }

--- a/packages/core/src/passive.ts
+++ b/packages/core/src/passive.ts
@@ -76,20 +76,22 @@ class PassiveCellRenderer implements IPassiveCell {
       return;
     }
     if (this.area.isAttached) {
+      // TODO should we detach and reattach?
       console.warn(`thebe:renderer:attachToDOM - already attached`);
       if (strict) return;
+    } else {
+      // if the target element has contents, preserve it but wrap it in our output area
+      console.debug(`thebe:renderer:attachToDOM ${this.id} - appending existing contents`);
+      if (el.innerHTML) {
+        this.area.model.add({
+          output_type: 'display_data',
+          data: {
+            'text/html': el.innerHTML,
+          },
+        });
+      }
     }
-    console.debug(`thebe:renderer:attachToDOM ${this.id}`);
 
-    // if the target element has contents, preserve it but wrap it in our output area
-    if (el.innerHTML) {
-      this.area.model.add({
-        output_type: 'display_data',
-        data: {
-          'text/html': el.innerHTML,
-        },
-      });
-    }
     el.textContent = '';
 
     const div = document.createElement('div');

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -26,7 +26,7 @@ class ThebeSession {
 
     this.events.triggerStatus({
       status: SessionStatusEvent.ready,
-      message: `New session started, kernel '${this.connection.kernel?.name}' available`,
+      message: `ThebeSession created, kernel '${this.connection.kernel?.name}' available`,
     });
   }
 
@@ -59,7 +59,7 @@ class ThebeSession {
 
     this.events.triggerStatus({
       status: SessionStatusEvent.ready,
-      message: `New session started, kernel '${this.connection.kernel?.name}' available`,
+      message: `session restarted, kernel '${this.connection.kernel?.name}' available`,
     });
   }
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -93,6 +93,7 @@ export interface IThebeCell extends IPassiveCell {
   readonly isBusy: boolean;
   readonly isAttached: boolean;
   readonly tags: string[];
+  readonly executionCount: number | null;
 
   attachSession(session: ThebeSession): void;
   detachSession(): void;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -100,6 +100,9 @@ export interface IThebeCell extends IPassiveCell {
   execute(source?: string): Promise<IThebeCellExecuteReturn | null>;
   setAsBusy(): void;
   setAsIdle(): void;
+  initOutputs(initialOutputs: IOutput[], hideWidgets?: boolean): void;
+  reset(hideWidgets?: boolean): void;
+  refresh(hideWidgets?: boolean): void;
 }
 
 export interface IThebeCellExecuteReturn {


### PR DESCRIPTION
Some ongoing work to support integration of `thebe` in the `myst-theme`. The purpose of this PR is to extend `core` and `react` further to support more stateful use of `thebe` in applications. For example, being able to maintain multiple kernels/sessions on a server and navigate between pages that use them while maintaining consistent state in the DOM.

See https://github.com/executablebooks/myst-theme/pull/136 for the work driving these changes.