### PR TITLE
feat/cell kinds

### DIFF
--- a/.changeset/afraid-needles-drop.md
+++ b/.changeset/afraid-needles-drop.md
@@ -1,0 +1,5 @@
+---
+'thebe-core': minor
+---
+
+Adds a `kind` (`CellKind`) files to all `IThebeCell`s making it easy for consumers to differentiate between code and content cells. `NonExecutableCell` has also now been renamed to `MarkdownCell` in preparation for additional rendering and inline execution calabilities being introduced in future.

--- a/packages/core/src/cell.ts
+++ b/packages/core/src/cell.ts
@@ -1,4 +1,4 @@
-import type { IThebeCell, IThebeCellExecuteReturn, JsonObject } from './types';
+import type { CellKind, IThebeCell, IThebeCellExecuteReturn, JsonObject } from './types';
 import type ThebeSession from './session';
 import PassiveCellRenderer from './passive';
 import type { IRenderMimeRegistry } from '@jupyterlab/rendermime';
@@ -8,7 +8,8 @@ import { EventEmitter } from './emitter';
 import type { ICodeCell, IError, IOutput } from '@jupyterlab/nbformat';
 import { ensureString, shortId } from './utils';
 
-class ThebeCell extends PassiveCellRenderer implements IThebeCell {
+class ThebeCodeCell extends PassiveCellRenderer implements IThebeCell {
+  kind: CellKind;
   source: string;
   metadata: JsonObject;
   session?: ThebeSession;
@@ -27,6 +28,7 @@ class ThebeCell extends PassiveCellRenderer implements IThebeCell {
     rendermime: IRenderMimeRegistry,
   ) {
     super(id, rendermime);
+    this.kind = 'code';
     this.events = new EventEmitter(id, config, EventSubject.cell, this);
     this.notebookId = notebookId;
     this.source = source;
@@ -43,7 +45,7 @@ class ThebeCell extends PassiveCellRenderer implements IThebeCell {
     config: Config,
     rendermime: IRenderMimeRegistry,
   ) {
-    const cell = new ThebeCell(
+    const cell = new ThebeCodeCell(
       icc.id ?? shortId(),
       notebookId,
       ensureString(icc.source),
@@ -199,4 +201,4 @@ class ThebeCell extends PassiveCellRenderer implements IThebeCell {
   }
 }
 
-export default ThebeCell;
+export default ThebeCodeCell;

--- a/packages/core/src/events.ts
+++ b/packages/core/src/events.ts
@@ -1,4 +1,4 @@
-import type ThebeCell from './cell';
+import type ThebeCodeCell from './cell';
 import type ThebeNotebook from './notebook';
 import type ThebeServer from './server';
 import type ThebeSession from './session';
@@ -70,7 +70,7 @@ export enum ThebeEventType {
   'error' = 'error',
 }
 
-export type EventObject = ThebeServer | ThebeSession | ThebeNotebook | ThebeCell;
+export type EventObject = ThebeServer | ThebeSession | ThebeNotebook | ThebeCodeCell;
 
 export type StatusEvent =
   | ServerStatusEvent

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,8 +1,8 @@
 export { default as ThebeServer } from './server';
 export { default as ThebeSession } from './session';
 export { default as ThebeNotebook, CodeBlock } from './notebook';
-export { default as ThebeCell } from './cell';
-export { default as ThebeNonExecutableCell } from './cell_noexec';
+export { default as ThebeCodeCell } from './cell';
+export { default as ThebeNonExecutableCell } from './markdown';
 export { default as PassiveCellRenderer } from './passive';
 
 export * from './options';

--- a/packages/core/src/markdown.ts
+++ b/packages/core/src/markdown.ts
@@ -3,12 +3,20 @@ import type { ICell, IOutput } from '@jupyterlab/nbformat';
 import type { IRenderMimeRegistry } from '@jupyterlab/rendermime';
 import PassiveCellRenderer from './passive';
 import type ThebeSession from './session';
-import type { IThebeCell, IThebeCellExecuteReturn, JsonObject } from './types';
+import type { CellKind, IThebeCell, IThebeCellExecuteReturn, JsonObject } from './types';
 import { ensureString, shortId } from './utils';
 
-export default class NonExecutableCell extends PassiveCellRenderer implements IThebeCell {
+/**
+ * A Thebe cell that is exepected to contain markdown (or raw) source.
+ *
+ * Currently this just separates content cells from code cells and thebe provides no
+ * special handling for markdown cells.
+ *
+ */
+export default class ThebeMarkdownCell extends PassiveCellRenderer implements IThebeCell {
   id: string;
   notebookId: string;
+  kind: CellKind;
   source: string;
   busy: boolean;
   metadata: JsonObject;
@@ -21,6 +29,7 @@ export default class NonExecutableCell extends PassiveCellRenderer implements IT
     rendermime: IRenderMimeRegistry,
   ) {
     super(id, rendermime);
+    this.kind = 'markdown';
     this.id = id;
     this.notebookId = notebookId;
     this.source = source;
@@ -29,7 +38,7 @@ export default class NonExecutableCell extends PassiveCellRenderer implements IT
   }
 
   static fromICell(ic: ICell, notebookId: string, rendermime: IRenderMimeRegistry) {
-    const cell = new NonExecutableCell(
+    const cell = new ThebeMarkdownCell(
       typeof ic.id === 'string' ? ic.id : shortId(),
       notebookId,
       ensureString(ic.source),

--- a/packages/core/src/notebook.ts
+++ b/packages/core/src/notebook.ts
@@ -1,4 +1,4 @@
-import ThebeCell from './cell';
+import ThebeCodeCell from './cell';
 import type ThebeSession from './session';
 import type { IThebeCell, IThebeCellExecuteReturn } from './types';
 import { shortId } from './utils';
@@ -7,7 +7,7 @@ import type { Config } from './config';
 import { EventSubject, NotebookStatusEvent } from './events';
 import { EventEmitter } from './emitter';
 import type { ICodeCell, INotebookContent, INotebookMetadata } from '@jupyterlab/nbformat';
-import NonExecutableCell from './cell_noexec';
+import ThebeMarkdownCell from './markdown';
 
 export interface CodeBlock {
   id: string;
@@ -37,7 +37,7 @@ class ThebeNotebook {
     const notebook = new ThebeNotebook(id, config, rendermime);
     notebook.cells = blocks.map((c) => {
       const metadata = {};
-      const cell = new ThebeCell(c.id, id, c.source, config, metadata, notebook.rendermime);
+      const cell = new ThebeCodeCell(c.id, id, c.source, config, metadata, notebook.rendermime);
       console.debug(`thebe:notebook:fromCodeBlocks Initializing cell ${c.id}`);
       return cell;
     });
@@ -52,8 +52,13 @@ class ThebeNotebook {
 
     notebook.cells = ipynb.cells.map((c) => {
       if ((c as ICodeCell).cell_type === 'code')
-        return ThebeCell.fromICodeCell(c as ICodeCell, notebook.id, config, notebook.rendermime);
-      return NonExecutableCell.fromICell(c, notebook.id, notebook.rendermime);
+        return ThebeCodeCell.fromICodeCell(
+          c as ICodeCell,
+          notebook.id,
+          config,
+          notebook.rendermime,
+        );
+      return ThebeMarkdownCell.fromICell(c, notebook.id, notebook.rendermime);
     });
 
     return notebook;

--- a/packages/core/src/notebook.ts
+++ b/packages/core/src/notebook.ts
@@ -80,6 +80,14 @@ class ThebeNotebook {
     return this.cells[this.cells.length - 1];
   }
 
+  get markdown() {
+    return this.cells.filter((c) => c.kind === 'markdown');
+  }
+
+  get code() {
+    return this.cells.filter((c) => c.kind === 'code');
+  }
+
   /**
    * reset the notebook to its initial state by resetting each cell
    *

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -5,6 +5,8 @@ import type { IRenderMimeRegistry } from '@jupyterlab/rendermime';
 import type ThebeServer from './server';
 import type { ServerStatusEvent } from './events';
 
+export type CellKind = 'code' | 'markdown';
+
 export type JsonObject = Record<string, any>;
 export type SessionIModel = Session.IModel;
 export type KernelISpecModels = KernelSpecAPI.ISpecModels;
@@ -86,6 +88,7 @@ export interface IPassiveCell {
 }
 
 export interface IThebeCell extends IPassiveCell {
+  kind: CellKind;
   source: string;
   session?: ThebeSession;
   metadata: JsonObject;


### PR DESCRIPTION
This PR introduces a field `kind` into `IThebeCells` making it easier to discriminate between `code` and `markdown` at runtime. `NonExecutableCell` has now been renamed to `MarkdownCell` and the `ThebeNotebook` has some helpful accessors.

This change was prompted by use in `myst-theme` where management of the busy state is buggy due to the difficulty in being able to make this discrimination. See https://github.com/executablebooks/myst-theme/issues/160 and https://github.com/executablebooks/myst-theme/issues/155