### PR TITLE
fix/overflows

### DIFF
--- a/.changeset/curvy-flies-refuse.md
+++ b/.changeset/curvy-flies-refuse.md
@@ -1,0 +1,5 @@
+---
+'thebe-core': patch
+---
+
+Override a jupyter style to allow pages to control scroll behaviour on their output areas

--- a/packages/core/src/index.css
+++ b/packages/core/src/index.css
@@ -72,6 +72,6 @@
 }
 
 /* Overides for jupyter styles */
-.thebe-output .lm-Widget {
+.thebe-output .jp-OutputArea-child > .lm-Widget {
   overflow: auto;
 }

--- a/packages/core/src/index.css
+++ b/packages/core/src/index.css
@@ -70,3 +70,8 @@
   font-family: monospace;
   margin: 8px 16px;
 }
+
+/* Overides for jupyter styles */
+.thebe-output .lm-Widget {
+  overflow: auto;
+}


### PR DESCRIPTION
enables scrolling on long outputs, should the containing page opt in with their container's css