### PR TITLE
remove `name` from `kernelOptions`

### DIFF
--- a/packages/core/src/options.ts
+++ b/packages/core/src/options.ts
@@ -33,7 +33,6 @@ export function makeKernelOptions(opts: KernelOptions): Required<KernelOptions> 
   return {
     path: opts.path ?? '/',
     kernelName: opts.kernelName ?? 'python',
-    name: opts.name ?? opts.kernelName ?? 'python',
   };
 }
 

--- a/packages/core/src/server.ts
+++ b/packages/core/src/server.ts
@@ -90,10 +90,19 @@ class ThebeServer implements ServerRuntime, ServerRestAPI {
       throw Error('Requesting session from a server, with no SessionManager available');
     }
 
-    // TODO can we defer connection setup, return the session immediately and then have a ready signal?
+    // name is assumed to be a non empty string but is otherwise note required
+    // if a notebook name has been supplied on the path, use that otherwise use a default
+    // https://jupyterlab.readthedocs.io/en/3.4.x/api/modules/services.session.html#isessionoptions
+    const path = kernelOptions?.path ?? this.config.kernels.path;
+    let name = 'thebe.ipynb';
+    const match = path.match(/\/*([a-zA-Z0-9]+.ipynb)$/);
+    if (match) {
+      name = match[1];
+    }
+
     const connection = await this.sessionManager?.startNew({
-      name: kernelOptions?.name ?? kernelOptions?.kernelName ?? this.config.kernels.name,
-      path: kernelOptions?.path ?? this.config.kernels.path,
+      name,
+      path,
       type: 'notebook',
       kernel: {
         name: kernelOptions?.kernelName ?? this.config.kernels.kernelName,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -69,7 +69,6 @@ export interface ServerSettings {
 }
 
 export interface KernelOptions {
-  name?: string;
   kernelName?: string;
   path?: string;
 }

--- a/packages/core/tests/config.spec.ts
+++ b/packages/core/tests/config.spec.ts
@@ -24,7 +24,6 @@ describe('config', () => {
     test('kernels', () => {
       expect(config.kernels).toEqual({
         path: '/',
-        name: 'python',
         kernelName: 'python',
       });
     });

--- a/packages/core/tests/options.spec.ts
+++ b/packages/core/tests/options.spec.ts
@@ -58,7 +58,6 @@ describe('options', () => {
     test('defaults', () => {
       expect(makeKernelOptions({})).toEqual({
         path: '/',
-        name: 'python',
         kernelName: 'python',
       });
     });
@@ -66,12 +65,10 @@ describe('options', () => {
       expect(
         makeKernelOptions({
           path: '/notebooks',
-          name: 'julia',
           kernelName: 'ijpl1',
         }),
       ).toEqual({
         path: '/notebooks',
-        name: 'julia',
         kernelName: 'ijpl1',
       });
     });
@@ -83,7 +80,6 @@ describe('options', () => {
         }),
       ).toEqual({
         path: '/notebooks',
-        name: 'ijpl1',
         kernelName: 'ijpl1',
       });
     });


### PR DESCRIPTION
To date the use of `name` in the options has been confused. In Jupyterlab this name should refer to the notebook name but in `thebe` the notebook concept does not apply in the same way, and the name parameter has been confused with the `kernelName` in some issues e.g. https://github.com/executablebooks/thebe/issues/595 and https://github.com/executablebooks/sphinx-thebe/pull/60.

This change reinforces the use of `kernelName` which is more meaningful, and probably means we'll need to revert the change in `sphinx-thebe` to go back to using `kernelName`.