### PR TITLE
✨ improve caching on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,16 +36,10 @@ jobs:
 
       # Action Repo: https://github.com/actions/setup-node
       - name: 'Setup Node'
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: '16'
-
-      # Action Repo: https://github.com/actions/cache
-      - name: 'Cache node_modules'
-        uses: actions/cache@v3
-        with:
-          path: node_modules
-          key: ${{ runner.os }}-npm-${{ hashFiles('package-lock.json') }}
+          cache: 'npm'
 
       - name: 'Install dependencies'
         run: |
@@ -62,8 +56,7 @@ jobs:
           CACHE_NUMBER: 0
         with:
           path: ~/conda_pkgs_dir
-          key: ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-${{
-            hashFiles('environment.test.yml') }}
+          key: ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-${{hashFiles('environment.test.yml') }}
 
       - name: Install conda environment
         uses: conda-incubator/setup-miniconda@v2
@@ -71,6 +64,7 @@ jobs:
           activate-environment: jupyter-server
           environment-file: environment.test.yml
           python-version: 3.9
+          use-only-tar-bz2: true # IMPORTANT: This needs to be set for caching to work properly!
 
       - name: 'Run tests'
         shell: bash -l {0}

--- a/.github/workflows/deploy-demo-pr-preview.yml
+++ b/.github/workflows/deploy-demo-pr-preview.yml
@@ -12,11 +12,12 @@ jobs:
     steps:
       - name: 'Checkout repo'
         uses: actions/checkout@v3
-      - name: 'Cache node_modules'
-        uses: actions/cache@v3
+      # Action Repo: https://github.com/actions/setup-node
+      - name: 'Setup Node'
+        uses: actions/setup-node@v2
         with:
-          path: node_modules
-          key: ${{ runner.os }}-npm-${{ hashFiles('package-lock.json') }}
+          node-version: '16'
+          cache: 'npm'
       - name: 'Install'
         run: npm ci
       - name: 'Build libs'

--- a/.github/workflows/deploy-demo-simple.yml
+++ b/.github/workflows/deploy-demo-simple.yml
@@ -13,6 +13,13 @@ jobs:
       - name: Checkout 🛎️
         uses: actions/checkout@v3
 
+      # Action Repo: https://github.com/actions/setup-node
+      - name: 'Setup Node'
+        uses: actions/setup-node@v2
+        with:
+          node-version: '16'
+          cache: 'npm'
+
       - name: Install and Build 🔧 # This example project is built using npm and outputs the result to the 'build' folder. Replace with the commands required to build your project, or remove this step entirely if your site is pre-built.
         run: |
           npm ci

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -12,10 +12,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v2
         with:
-          node-version: 15
+          node-version: 16
           registry-url: https://registry.npmjs.org/
+          cache: 'npm'
       - run: npm ci
       - run: npm run build:publish
       - run: npm publish

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -19,6 +19,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 16
+          cache: 'npm'
 
       - name: Install Dependencies
         run: npm install


### PR DESCRIPTION
* using `cache: npm` option on `setup-node` action in place of attempting to cache the node_modules folder
* added `use-only-tar-bz2` option to properly enable conde caching as per action readme