### PR TITLE
fix/server blatting

### DIFF
--- a/.changeset/metal-humans-beg.md
+++ b/.changeset/metal-humans-beg.md
@@ -1,0 +1,5 @@
+---
+'thebe-core': patch
+---
+
+Add check call for user server status

--- a/.changeset/soft-countries-invite.md
+++ b/.changeset/soft-countries-invite.md
@@ -1,0 +1,6 @@
+---
+'demo-react': patch
+'thebe-react': patch
+---
+
+ThebeServerProvider will no longer replace an existing server on rerender if that server is ready and has user server URL.

--- a/packages/core/src/server.ts
+++ b/packages/core/src/server.ts
@@ -79,6 +79,13 @@ class ThebeServer implements ServerRuntime, ServerRestAPI {
     return this.sessionManager?.shutdownAll();
   }
 
+  async check(): Promise<boolean> {
+    const resp = await ThebeServer.status(
+      this.sessionManager?.serverSettings ?? this.config.serverSettings,
+    );
+    return resp.ok;
+  }
+
   dispose() {
     if (this._isDisposed) return;
     if (!this.serviceManager?.isDisposed) this.serviceManager?.dispose();
@@ -318,6 +325,7 @@ class ThebeServer implements ServerRuntime, ServerRestAPI {
         });
 
         return this.sessionManager.ready.then(() => {
+          this.userServerUrl = `${serverSettings.baseUrl}?token=${serverSettings.token}`;
           this.events.triggerStatus({
             status: ServerStatusEvent.ready,
             message: `Re-connected to binder server`,
@@ -438,7 +446,7 @@ class ThebeServer implements ServerRuntime, ServerRestAPI {
     return url;
   }
 
-  static status(serverSettings: Required<ServerSettings>): Promise<void | Response> {
+  static status(serverSettings: ServerSettings) {
     return ServerConnection.makeRequest(
       `${serverSettings.baseUrl}api/status`,
       {},

--- a/packages/react/src/ThebeServerProvider.tsx
+++ b/packages/react/src/ThebeServerProvider.tsx
@@ -60,14 +60,18 @@ export function ThebeServerProvider({
   );
 
   useEffect(() => {
-    if (!core || !thebeConfig) return;
+    if (!core || !thebeConfig || server) return;
     setServer(new core.ThebeServer(thebeConfig));
-  }, [core, thebeConfig]);
+  }, [core, thebeConfig, server]);
 
   // Once the core is loaded, connect to a server
+  // TODO: this should be an action not a side effect
   useEffect(() => {
     if (!core || !thebeConfig) return; // TODO is there a better way to keep typescript happy here?
     if (!server || !doConnect) return;
+    // do not reconnect if already connected!
+    if (server.isReady && server.userServerUrl) return;
+    // TODO is the user server really still alive? this would be an async call to server.check
     setConnecting(true);
     if (customConnectFn) customConnectFn(server);
     else if (useBinder) server.connectToServerViaBinder(customRepoProviders);


### PR DESCRIPTION
The `ThebeServerProvider` could replace active servers during navigaion easily, these changes protect against that by checking to see if the server is already "ready" and has a user server url.

This complements well the existing `disconnect` functionality.