### PR TITLE
typos

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@
 
 The main `thebe` packages are located in `packages/` and are:
 
-- `thebe-core` - object based API for connecting to and executing against juptyer servers
+- `thebe-core` - object based API for connecting to and executing against jupyter servers
 - `thebe-lite` - a side-loaded extension to `thebe-core` enabling use of a `JupyterLiteServer`
 - `thebe-react` - React components for using `thebe-core`
 - `thebe` - top-level library for use directly in html pages

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 >
 > `thebe` 0.9.0 is still under development and documentation is work in progress (PRs welcome!)
 
-Thebe is a set of libraries allowing web applications and static web pages to provide interactive computation backed by a Juptyer kernel. It is organized in multiple libraries to allow it to be used flexibly in different web contexts.
+Thebe is a set of libraries allowing web applications and static web pages to provide interactive computation backed by a Jupyter kernel. It is organized in multiple libraries to allow it to be used flexibly in different web contexts.
 
 Thebe comprises the following packages (located in the `packages/` folder in this repo):
 
@@ -28,7 +28,7 @@ The latest thebe documentation is build using [mystmd](https://mystmd.org) and i
 
 ## Demos
 
-The demo page from `apps/simple` are hosted [here on github pages](https://executablebooks.github.io/thebe) which let's you check out the interactivity that the top level `thebe` library provides along with `thebe-lite` for JuptyerLite based `pyodide` kernel access.
+The demo page from `apps/simple` are hosted [here on github pages](https://executablebooks.github.io/thebe) which let's you check out the interactivity that the top level `thebe` library provides along with `thebe-lite` for JupyterLite based `pyodide` kernel access.
 
 ## Development Setup
 

--- a/apps/demo-core/CHANGELOG.md
+++ b/apps/demo-core/CHANGELOG.md
@@ -23,7 +23,7 @@
 
 ### Patch Changes
 
-- Improved all demos and setup autodeply for the simple demo
+- Improved all demos and setup autodeploy for the simple demo
 - Updated dependencies
   - thebe-core@0.2.1
 

--- a/apps/demo-react/CHANGELOG.md
+++ b/apps/demo-react/CHANGELOG.md
@@ -50,7 +50,7 @@
 
 ### Patch Changes
 
-- Updated interface to allow jupyterlite options to be passed into bundle. React provider updated to access useJuptyerLite prop and react-demo updated to use the new prop.
+- Updated interface to allow jupyterlite options to be passed into bundle. React provider updated to access useJupyterLite prop and react-demo updated to use the new prop.
 - Updated dependencies
   - thebe-react@0.2.1
 
@@ -58,7 +58,7 @@
 
 ### Patch Changes
 
-- Improved all demos and setup autodeply for the simple demo
+- Improved all demos and setup autodeploy for the simple demo
 - Updated dependencies
   - thebe-react@1.0.0
 

--- a/apps/docs-core/0-installation.md
+++ b/apps/docs-core/0-installation.md
@@ -25,5 +25,5 @@ Or load the `thebe-core` bundle in your browser:
 ## Next steps
 
 - follow the [in browser guide](2-guide-browser.md)
-- follow the [tyepscript guide](3-guide-typescript.md)
+- follow the [typescript guide](3-guide-typescript.md)
 - or if you want something quick try the typescript [quick start](1-quickstart.md)

--- a/apps/docs-core/9-building-thebe-core.md
+++ b/apps/docs-core/9-building-thebe-core.md
@@ -8,7 +8,7 @@ venue: development
 
 The main `thebe` packages are located in `packages/` and are:
 
-- `thebe-core` - object based API for connecting to and executing against juptyer servers
+- `thebe-core` - object based API for connecting to and executing against jupyter servers
 - `thebe-lite` - a side-loaded extension to `thebe-core` enabling use of a `JupyterLiteServer`
 - `thebe` - top-level library for use directly in html pages
 

--- a/apps/docs-core/CHANGELOG.md
+++ b/apps/docs-core/CHANGELOG.md
@@ -10,16 +10,16 @@
 
 ### Patch Changes
 
-- Updated interface to allow jupyterlite options to be passed into bundle. React provider updated to access useJuptyerLite prop and react-demo updated to use the new prop.
+- Updated interface to allow jupyterlite options to be passed into bundle. React provider updated to access useJupyterLite prop and react-demo updated to use the new prop.
 
 ## 1.0.2
 
 ### Patch Changes
 
-- Improved all demos and setup autodeply for the simple demo
+- Improved all demos and setup autodeploy for the simple demo
 
 ## 1.0.1
 
 ### Patch Changes
 
-- Removed the typedoc `references` folder, whcih is now ignored and always generated on `npm run docs`.
+- Removed the typedoc `references` folder, which is now ignored and always generated on `npm run docs`.

--- a/apps/docs-core/architecture.md
+++ b/apps/docs-core/architecture.md
@@ -12,15 +12,15 @@ The main objects provided are shown below in their default configuration.
 
 In each object only some key members / properties are shown, the role of these and their scope is explained below:
 
-- A `Config` object holds the set of current options alongside a `ThebeEvents` instance. A configuration culd be provided per application or per page.
-  - `ThebeEvents` is an object that provided `jquery`-like events interface `trigger`, `on`, `one`, `off`, all objects that receive the `configc instance will use the same events object.
+- A `Config` object holds the set of current options alongside a `ThebeEvents` instance. A configuration could be provided per application or per page.
+  - `ThebeEvents` is an object that provided `jquery`-like events interface `trigger`, `on`, `one`, `off`, all objects that receive the `config` instance will use the same events object.
 - A `ThebeServer` holds the `SessionManager` (`ServiceManager` in the case of JupyterLite)
-  - it provides member function to establish a connecton
+  - it provides member function to establish a connection
   - it provides functions to start a new or connect to an existing session/kernel
 - A `ThebeSession` holds a kernel connection and is used to interact with the kernel
   - The session also creates an instance of a `WidgetManager` that is shared between all `RendermimeRegistryies` in notebooks or cells that attach to it
-- A `ThebeNotebook` holds a list of cells and provides funcitons to load source code into cells and execute them
-  - A notebook holds a `RendermimeRegistry` that is shared with aii it's cells
+- A `ThebeNotebook` holds a list of cells and provides functions to load source code into cells and execute them
+  - A notebook holds a `RendermimeRegistry` that is shared with all its cells
 - A `ThebeCell` holds source code and can be executed in a session.
   - `ThebeCell` inherits from `PassiveThebeCell` which is only concerned with attaching to the DOM and rendering an `OutputArea`
   - If created independently of a `ThebeNotebook` it will hold it's own instance of a `RendermimeRegistry`

--- a/apps/docs-core/history.md
+++ b/apps/docs-core/history.md
@@ -10,4 +10,4 @@ However, it was `jquery` centric and focussed on making a web page containing st
 
 The purpose of `thebe-core` is to isolate and expand the core functionality in `thebe` so that it could be used in different ways in a wider range of web contexts, from simple html pages through to web applications using frameworks like `React` or `Next.js`, whilst still being used internally in `thebe` providing a **like-for-like** behaviour there.
 
-Refactoring the `thebe` like this, allows interesting enhancements to be made including connecting to a `juptyerlite` kernel and providing a simplified runtime interface for interacting with Jupyter servers and sessions.
+Refactoring the `thebe` like this, allows interesting enhancements to be made including connecting to a `jupyterlite` kernel and providing a simplified runtime interface for interacting with Jupyter servers and sessions.

--- a/apps/docs-core/index.md
+++ b/apps/docs-core/index.md
@@ -31,7 +31,7 @@ The `thebe` library is published as a collection of sub-packages on [npm](https:
 : Use when you have a static HTML website or a framework where you can add scripts to load the javascript bundle and set configuraton options easily. You're happy with loading codemirror to make all selected `<pre>` tags into editors and the default `thebe` UI. See [quickstart](/thebe/quickstart) or [using `thebe`](/thebe/using-thebe).
 
 `thebe-core`
-: Use when you are adding jupyter based computation into a typescript application, when you want Jupyter outputs on your webpage but you don't want to show all the code or when you want `thebe`-like behaviour, but want to complete control tover the UI and kernel connections. See [using `thebe-core`](/thebe/using-core).
+: Use when you are adding jupyter based computation into a typescript application, when you want Jupyter outputs on your webpage but you don't want to show all the code or when you want `thebe`-like behaviour, but want to complete control over the UI and kernel connections. See [using `thebe-core`](/thebe/using-core).
 
 `thebe-lite`
 : Add this library alongside any other sub-package when you want to enable in-browser computation with the `useJupyterLite` option. See [using `thebe-lite`](/thebe/using-thebe-lite).

--- a/apps/docs-core/quickstart-binder.md
+++ b/apps/docs-core/quickstart-binder.md
@@ -20,7 +20,7 @@ Add the following to the `<head>` section of your HTML:
 This will:
 
 - Load the javascript bundle for the latest Release Candidate version of `thebe`.
-- Load the styles for the same version, including the styles you'll need for rendering Juptyer outputs and ipywidgets properly.
+- Load the styles for the same version, including the styles you'll need for rendering Jupyter outputs and ipywidgets properly.
 
 ## Configure `thebe` to work with binder
 
@@ -42,7 +42,7 @@ This is very compact as `thebe` will assume the default repository provider is `
 
 ## Add some UI elements
 
-Thebe provides some default UI componponents that can be customixed via css. To add these components to your page add the following `html` elements in desired location.
+Thebe provides some default UI components that can be customised via css. To add these components to your page add the following `html` elements in desired location.
 Add at least the first element to have a way to activate`thebe`.
 
 ```{code-block} xml

--- a/apps/docs-core/quickstart-lite.md
+++ b/apps/docs-core/quickstart-lite.md
@@ -30,7 +30,7 @@ This is dependent on you making `thebe` and `thebe-lite` available as part of yo
 
 - Load the latest javascipt bundle for `thebe-lite`.
 - Load the javascript bundle for `thebe`.
-- Load the styles you'll need for rendering Juptyer outputs and ipywidgets properly.
+- Load the styles you'll need for rendering Jupyter outputs and ipywidgets properly.
 
 You should include the following files in your deployment:
 
@@ -58,7 +58,7 @@ Enable the JupyterLite server by adding the follow configuration script to the `
 
 `thebe-lite` is currently limited to using the `pyodide` kernel. By default, `thebe-lite` will look for python (WASM) wheels (`.whl`) on relative paths, meaning you have to take care to also deploy them and ensure they are reachable on the expected url paths (more on that in [`thebe-lite` options](./lite-options.md)).
 
-But we can avoid that by overriding some JuptyerLite settings directly, and load the wheels from CDN. This makes inital setup much easier!
+But we can avoid that by overriding some JupyterLite settings directly, and load the wheels from CDN. This makes initial setup much easier!
 
 Do this by adding an additional `script` to the `<head>` of your page, **above** the `<script>` tags that load `thebe-lite`:
 
@@ -78,11 +78,11 @@ Do this by adding an additional `script` to the `<head>` of your page, **above**
 </script>
 ```
 
-Note due to the namin convention of the `piplite` wheel, it's necessary to keep this updated to the latest version manually.
+Note due to the naming convention of the `piplite` wheel, it's necessary to keep this updated to the latest version manually.
 
 ## Add some UI elements
 
-Thebe provides some default UI componponents that can be customixed via css. To add these components to your page add the following `html` elements in desired location.
+Thebe provides some default UI components that can be customised via css. To add these components to your page add the following `html` elements in desired location.
 Add at least the first element to have a way to activate`thebe`.
 
 ```{code-block} xml
@@ -98,7 +98,7 @@ Then extend the configuration script that you added above to enable the widgets,
 <script type="text/x-thebe-config">
   {
       useBinder: false,
-      useJuptyerLite: true,
+      useJupyterLite: true,
       mountActivateWidget: true,
       mountStatusWidget: true,
   }
@@ -109,7 +109,7 @@ Provided that the `thebe` script and styles are properly loaded, when you refres
 
 ![](./images/thebe-ui-widgets.png)
 
-Pressing activate should start the in-browser Juptyer server and setup the kernel but before you do that! Let's make sure that `thebe` will be able to find the source code on your site.
+Pressing activate should start the in-browser Jupyter server and setup the kernel but before you do that! Let's make sure that `thebe` will be able to find the source code on your site.
 
 ## Customising the source code selector
 

--- a/apps/docs-core/react-intro.md
+++ b/apps/docs-core/react-intro.md
@@ -15,9 +15,9 @@ Install with `npm`:
 
 `thebe-react` is a react wrapper for `thebe-core`. Integrating `thebe-core` into a React based web application presents similar challenges to integrating any stateful 3rd party library that directly manipulates the DOM.
 
-The best approach likely depends on how your application uses jupyter backed components and handles concerns like data (notebook) loading, navigation and dynamic rendering. The components in this library represent a good starting point, but you may need to build your own react components on `thebe-core` to acheive the behaviour you want.
+The best approach likely depends on how your application uses jupyter backed components and handles concerns like data (notebook) loading, navigation and dynamic rendering. The components in this library represent a good starting point, but you may need to build your own react components on `thebe-core` to achieve the behaviour you want.
 
-The `thebe-react` library uses the React Context API and gives you a set of [Providers and hooks for Server and Session management](./react-providers.md) as well as [hooks for working with notebook and source code fragments](./react-notebooks.md). These work well in certain applicaiton setups and one such setup is the demo `create-react-app` application that you can find in [`apps/demo-react`](https://github.com/executablebooks/thebe/tree/main/apps/demo-react), this is an excellent point of reference.
+The `thebe-react` library uses the React Context API and gives you a set of [Providers and hooks for Server and Session management](./react-providers.md) as well as [hooks for working with notebook and source code fragments](./react-notebooks.md). These work well in certain application setups and one such setup is the demo `create-react-app` application that you can find in [`apps/demo-react`](https://github.com/executablebooks/thebe/tree/main/apps/demo-react), this is an excellent point of reference.
 
 It will also help to review the [`thebe-core`'s underlying API](./using-thebe-core) as these `thebe-core` runtime objects are exposed by the react providers and hooks.
 

--- a/apps/docs-core/react-providers.md
+++ b/apps/docs-core/react-providers.md
@@ -7,7 +7,7 @@ The Context API is used to make the main objects from `thebe-core` available to 
 
 ```{tip}
 :class: dropdown
-As `thebe-core` makes use of packages and UI components from Juptyer Lab, the providers are setup to dynamically load the libraries. This can be helpful avoid issues with different build systems and Server Side Rendering (SSR).
+As `thebe-core` makes use of packages and UI components from Jupyter Lab, the providers are setup to dynamically load the libraries. This can be helpful avoid issues with different build systems and Server Side Rendering (SSR).
 ```
 
 The providers are:
@@ -32,9 +32,9 @@ Once the core library is loaded a server connection can be established, whilst i
 
 ```{tip}
 :class: dropdown
-In Jupyter Lab and Juptyer notebooks front end implementations, a mapping of 1 session/kernel per document is maintained and this is also the way in whcih `thebe-react` and `thebe-core` are configured by default.
+In Jupyter Lab and Jupyter notebooks front end implementations, a mapping of 1 session/kernel per document is maintained and this is also the way in which `thebe-react` and `thebe-core` are configured by default.
 
-Think about this when deciding how to distribute `ThebeSessions` accross pages/screens in your application. This is important as using a single session across pages means that they are sharing a common kernel,  variable scope, and `ipywidget` manager (See [`Using ipywidgets`](/thebe/using-ipywidgets) for details on thathe latter).
+Think about this when deciding how to distribute `ThebeSessions` across pages/screens in your application. This is important as using a single session across pages means that they are sharing a common kernel,  variable scope, and `ipywidget` manager (See [`Using ipywidgets`](/thebe/using-ipywidgets) for details on thathe latter).
 ```
 
 A typical provider cascade is:
@@ -94,7 +94,7 @@ export declare function useThebeCore(): {
 : Can be used to trigger async loading of the `thebe-core` library by a child component.
 
 `loading: boolean`
-: will be `true` during ashync loading.
+: will be `true` during async loading.
 
 `error?: string | undefined`
 : If an exception occurs, the message will be provided here.
@@ -155,23 +155,23 @@ It accepts a number of props:
 : Accepts an external `Config` object, which if supplied will cause `options` to be ignored **(consider deprecation)**.
 
 `events: ThebeEvents`
-: Accepts an exernal `ThebeEvents` object, allowing for custom configuation of the event emitter used in `thebe-core` objects or for sharing of one event emitter accross multiple server connections **(consider deprecation)**.
+: Accepts an external `ThebeEvents` object, allowing for custom configuration of the event emitter used in `thebe-core` objects or for sharing of one event emitter across multiple server connections **(consider deprecation)**.
 
 `useBinder: boolean`
-: Will invoke `server.connectToServerViaBinder` to establish a server connection. This takes precedence over `useJuptyerLite` but will have no effect if `customConnectFn` is supplied.
+: Will invoke `server.connectToServerViaBinder` to establish a server connection. This takes precedence over `useJupyterLite` but will have no effect if `customConnectFn` is supplied.
 
-`useJuptyerLite: boolean`
-: Will start the in-browser JuptyerLite server but will have no effect if either `useBinder: true` or a `customConnectFn` is provided.
+`useJupyterLite: boolean`
+: Will start the in-browser JupyterLite server but will have no effect if either `useBinder: true` or a `customConnectFn` is provided.
 
 `customConnectFn: (server: ThebeServer) => void`
-: Supply a function that can establish a connection for the `server` object provided in the argument. The `server` ojbect will be a fresh instance that should be updated to reflect the state of the server after the connection attempt is complete. One use of this option would be to provision of a server on a Jupyter Hub via an authenitcated API call.
+: Supply a function that can establish a connection for the `server` object provided in the argument. The `server` object will be a fresh instance that should be updated to reflect the state of the server after the connection attempt is complete. One use of this option would be to provision of a server on a Jupyter Hub via an authenticated API call.
 
 ### hooks
 
 Three convenience hooks are available for use with the provider. Each will throw on an `undefined` context, otherwise returning the object specified:
 
 `useThebeConfig`
-: The first will return the configuation object from the server context.
+: The first will return the configuration object from the server context.
 
 `useDisposeThebeServer`
 : On rendering a child component with this hook, the serve will be shutdown (including all sessions) and disposed.
@@ -213,7 +213,7 @@ Three convenience hooks are available for use with the provider. Each will throw
 : A helper function to add an event listener to the `ThebeEvent`'s emitter that is scoped to this server.
 
 `unsubAll`
-: Will unsubscribe all listers that were added via `subscribe`
+: Will unsubscribe all listeners that were added via `subscribe`
 
 ### ThebeSessionProvider
 
@@ -263,4 +263,4 @@ A single convenience hook is available. This will throw on an `undefined` contex
 : Request a session/kernel from within a child component. This will only work if a `ThebeServer` is available and ready.
 
 `shutdown`
-: Trigger shudown of the current session.
+: Trigger shutdown of the current session.

--- a/apps/docs-core/react-ui-components.md
+++ b/apps/docs-core/react-ui-components.md
@@ -11,4 +11,4 @@ ErrorTray
 : Used to display out-of-band error messages from ThebeNotebook. As errors could occur in notebook cells that are not attached to you page, the `ErrorTray` will help you display those with the standard Jupyter formatting for errors and tracebacks.
 
 JupyterOutputDecoration
-: Can be used to a bounding box and Juptyer Logo to your jupyter output areas.
+: Can be used to a bounding box and Jupyter Logo to your jupyter output areas.

--- a/apps/docs-core/ref-core-browser.md
+++ b/apps/docs-core/ref-core-browser.md
@@ -45,7 +45,7 @@ The asynchronous [`connect`](reference/modules.md#connect) function will establi
 const server = await connect(config);
 ```
 
-Once resolved it provides a `ThebeServer` object that can be used to start a new session / kernel. The configuration object is availble on `server.config`.
+Once resolved it provides a `ThebeServer` object that can be used to start a new session / kernel. The configuration object is available on `server.config`.
 
 ```typescript
 ...

--- a/apps/docs-core/using-thebe-react.md
+++ b/apps/docs-core/using-thebe-react.md
@@ -3,7 +3,7 @@ title: Using thebe-react
 venue: Guides
 ---
 
-Integrating `thebe-core` into a React based web application presents similar challenges to integrating any stateful 3rd party library that directly manipulates the DOM. The best approach liekly depends on how your applications uses the jupyter backed components and handles concerns like data (notebook) loading, navigation and dynamic rendering. The components in this library represent a good starting point, but you may need to build your own react components on `thebe-core` to acheive the behaviour you want.
+Integrating `thebe-core` into a React based web application presents similar challenges to integrating any stateful 3rd party library that directly manipulates the DOM. The best approach likely depends on how your applications uses the jupyter backed components and handles concerns like data (notebook) loading, navigation and dynamic rendering. The components in this library represent a good starting point, but you may need to build your own react components on `thebe-core` to achieve the behaviour you want.
 
 The `thebe-react` library uses the React Context API and gives you a set of Providers and hooks that work well in certain setups. One such setup is the demo `create-react-app` application that you can find in [`apps/demo-react`](https://github.com/executablebooks/thebe/tree/main/apps/demo-react), and is an excellent point of reference.
 
@@ -22,7 +22,7 @@ Feedback, issues and PR's are very welcome.
 The Context API is used to make the main objects from `thebe-core` available to components in your render tree.
 
 ```{tip}
-As `thebe-core` makes use of packages and UI components from Juptyer Lab, the providers are setup to dynamically load the libraries. This can be helpful avoid issues with different build systems and Server Side Rendering (SSR).
+As `thebe-core` makes use of packages and UI components from Jupyter Lab, the providers are setup to dynamically load the libraries. This can be helpful avoid issues with different build systems and Server Side Rendering (SSR).
 ```
 
 The providers are:
@@ -43,9 +43,9 @@ Providers need to be structured in cascade within the React component tree.
 Once the core library is loaded a server connection can be established, whilst it's possible to have multiple server connections a common pattern is to establish a single server connection high up in your tree, while creating different sessions on different pages within navigation.
 
 ```{tip}
-In Jupyter Lab and Juptyer notebooks front end implementations, a mapping of 1 session/kernel per document is maintained and this is also the way in whcih `thebe-react` and `thebe-core` are configured by default.
+In Jupyter Lab and Jupyter notebooks front end implementations, a mapping of 1 session/kernel per document is maintained and this is also the way in which `thebe-react` and `thebe-core` are configured by default.
 
-Think about this when deciding how to distribute `ThebeSessions` accross pages/screens in your application. This is important as using a single session across pages means that they are sharing a common kernel,  variable scope, and `ipywidget` manager (See [`Using ipywidgets`](/thebe/using-ipywidgets) for details on thathe latter).
+Think about this when deciding how to distribute `ThebeSessions` across pages/screens in your application. This is important as using a single session across pages means that they are sharing a common kernel,  variable scope, and `ipywidget` manager (See [`Using ipywidgets`](/thebe/using-ipywidgets) for details on thathe latter).
 ```
 
 A typical provider cascade is:
@@ -102,7 +102,7 @@ export declare function useThebeCore(): {
 : Can be used to trigger async loading of the `thebe-core` library by a child component.
 
 `loading: boolean`
-: will be `true` during ashync loading.
+: will be `true` during async loading.
 
 `error?: string | undefined`
 : If an exception occurs, the message will be provided here.
@@ -141,23 +141,23 @@ It accepts a number of props:
 : Accepts an external `Config` object, which if supplied will cause `options` to be ignored **(consider deprecation)**.
 
 `events: ThebeEvents`
-: Accepts an exernal `ThebeEvents` object, allowing for custom configuation of the event emitter used in `thebe-core` objects or for sharing of one event emitter accross multiple server connections **(consider deprecation)**.
+: Accepts an external `ThebeEvents` object, allowing for custom configuration of the event emitter used in `thebe-core` objects or for sharing of one event emitter across multiple server connections **(consider deprecation)**.
 
 `useBinder: boolean`
-: Will invoke `server.connectToServerViaBinder` to establish a server connection. This takes precedence over `useJuptyerLite` but will have no effect if `customConnectFn` is supplied.
+: Will invoke `server.connectToServerViaBinder` to establish a server connection. This takes precedence over `useJupyterLite` but will have no effect if `customConnectFn` is supplied.
 
-`useJuptyerLite: boolean`
-: Will start the in-browser JuptyerLite server but will have no effect if either `useBinder: true` or a `customConnectFn` is provided.
+`useJupyterLite: boolean`
+: Will start the in-browser JupyterLite server but will have no effect if either `useBinder: true` or a `customConnectFn` is provided.
 
 `customConnectFn: (server: ThebeServer) => void`
-: Supply a function that can establish a connection for the `server` object provided in the argument. The `server` ojbect will be a fresh instance that should be updated to reflect the state of the server after the connection attempt is complete. One use of this option would be to provision of a server on a Jupyter Hub via an authenitcated API call.
+: Supply a function that can establish a connection for the `server` object provided in the argument. The `server` object will be a fresh instance that should be updated to reflect the state of the server after the connection attempt is complete. One use of this option would be to provision of a server on a Jupyter Hub via an authenticated API call.
 
 #### hooks
 
 Three convenience hooks are available for use with the provider. Each will throw on an `undefined` context, otherwise returning the object specified:
 
 `useThebeConfig`
-: The first will return the configuation object from the server context.
+: The first will return the configuration object from the server context.
 
 `useDisposeThebeServer`
 : On rendering a child component with this hook, the serve will be shutdown (including all sessions) and disposed.
@@ -199,7 +199,7 @@ Three convenience hooks are available for use with the provider. Each will throw
 : A helper function to add an event listener to the `ThebeEvent`'s emitter that is scoped to this server.
 
 `unsubAll`
-: Will unsubscribe all listers that were added via `subscribe`
+: Will unsubscribe all listeners that were added via `subscribe`
 
 ### ThebeSessionProvider
 
@@ -249,4 +249,4 @@ A single convenience hook is available. This will throw on an `undefined` contex
 : Request a session/kernel from within a child component. This will only work if a `ThebeServer` is available and ready.
 
 `shutdown`
-: Trigger shudown of the current session.
+: Trigger shutdown of the current session.

--- a/apps/docs/CHANGELOG.md
+++ b/apps/docs/CHANGELOG.md
@@ -4,4 +4,4 @@
 
 ### Patch Changes
 
-- Improved all demos and setup autodeply for the simple demo
+- Improved all demos and setup autodeploy for the simple demo

--- a/apps/simple/CHANGELOG.md
+++ b/apps/simple/CHANGELOG.md
@@ -16,4 +16,4 @@
 
 ### Patch Changes
 
-- Improved all demos and setup autodeply for the simple demo
+- Improved all demos and setup autodeploy for the simple demo

--- a/apps/simple/README.md
+++ b/apps/simple/README.md
@@ -3,7 +3,7 @@
 These demos use the `thebe` bundle. They show the simplest possible way to get `thebe` running on a page in some differetn scenarios:
 
 - Running on binder
-- Connecting directly to a Juptyer server (e.g. local)
-- With JuptyerLite
+- Connecting directly to a Jupyter server (e.g. local)
+- With JupyterLite
 
 ## building

--- a/apps/simple/static/ipywidgets-lite.html
+++ b/apps/simple/static/ipywidgets-lite.html
@@ -56,7 +56,7 @@
         <a href="https://jupyterlite.readthedocs.io/en/latest/">jupyterlite</a> project.
       </p>
       <p>
-        Thebe code that uses <code>juptyerlite</code> has been bindles separately in the
+        Thebe code that uses <code>jupyterlite</code> has been bindles separately in the
         <code>thebe-lite</code> library, which should be side-loaded on the page prior to
         <code>thebe</code> being loaded. <code>thebe-lite</code> is not a standalone library but
         when <code>thebe</code> is bootstrapped with the <code>useJupyterLite</code> option set, it

--- a/apps/simple/static/ipywidgets-local.html
+++ b/apps/simple/static/ipywidgets-local.html
@@ -41,7 +41,7 @@
     <div style="margin: 24px auto; max-width: 900px">
       <h1>ipywidgets using a local server</h1>
       <p>
-        To use this demo you to to have a juptyer server available and able to receive connections
+        To use this demo you to to have a jupyter server available and able to receive connections
         from <code>localhost</code>. To start a local server, use the following command:
       </p>
       <p>

--- a/apps/simple/static/jupyter.html
+++ b/apps/simple/static/jupyter.html
@@ -39,7 +39,7 @@
     <div style="margin: 24px auto; max-width: 900px">
       <h1>Simple plots using a local server</h1>
       <p>
-        To use this demo you to to have a juptyer server available and able to receive connections
+        To use this demo you to to have a jupyter server available and able to receive connections
         from <code>localhost</code>. To start a local server, use the following command:
       </p>
       <p>

--- a/apps/simple/static/lite.html
+++ b/apps/simple/static/lite.html
@@ -53,7 +53,7 @@
         <a href="https://jupyterlite.readthedocs.io/en/latest/">jupyterlite</a> project.
       </p>
       <p>
-        Thebe code that uses <code>juptyerlite</code> has been bindles separately in the
+        Thebe code that uses <code>jupyterlite</code> has been bindles separately in the
         <code>thebe-lite</code> library, which should be side-loaded on the page prior to
         <code>thebe</code> being loaded. <code>thebe-lite</code> is not a standalone library but
         when <code>thebe</code> is bootstrapped with the <code>useJupyterLite</code> option set, it

--- a/apps/simple/static/maths.html
+++ b/apps/simple/static/maths.html
@@ -50,7 +50,7 @@
         page (view html source for details).
       </p>
       <p>
-        To use this demo you to to have a juptyer server available and able to receive connections
+        To use this demo you to to have a jupyter server available and able to receive connections
         from <code>localhost</code>. To start a local server, use the following command:
       </p>
       <p>

--- a/apps/simple/static/paths.html
+++ b/apps/simple/static/paths.html
@@ -70,7 +70,7 @@
         </pre>
         <p>
         
-        to to have a juptyer server available and able to receive connections
+        to to have a jupyter server available and able to receive connections
         from <code>localhost</code>. To start a local server, use the following command:
       </p>
       <p>

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -64,7 +64,7 @@
 
 ### Patch Changes
 
-- dad3d19: The refresh function has been removed and the beahviour of render and reset tweaked to remove the hideWidgets option. This means that `stripWidgets` is no longer called and the consumer must implement any functionality to manipulate MimeBundles that contain `ipywidgets`, if they want to acheive better default rendering. `stripWidgets` and the defualt `placeholder` generation functions have been exposed on the `thebe-core` apip to make this easier.
+- dad3d19: The refresh function has been removed and the beahviour of render and reset tweaked to remove the hideWidgets option. This means that `stripWidgets` is no longer called and the consumer must implement any functionality to manipulate MimeBundles that contain `ipywidgets`, if they want to achieve better default rendering. `stripWidgets` and the defualt `placeholder` generation functions have been exposed on the `thebe-core` apip to make this easier.
   - thebe-lite@0.2.8
 
 ## 0.2.7

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -2,7 +2,7 @@
 
 `thebe-core` is a headless connector library allowing a developer to connect to and execute code on a Jupyter based compute resource from any Javascript environemnt.
 
-Written in Typescript and indended for use in other packages and applicaitons, `thebe-core` has minimal state and introduces no restrictions on UI frameworks that might be used. [thebe](https://github.com/executablebooks/thebe) will use `thebe-core` to provide a `jquery` based connector, that uses prosemirror to enable editing and execution of code cells on any webpage.
+Written in Typescript and indended for use in other packages and applications, `thebe-core` has minimal state and introduces no restrictions on UI frameworks that might be used. [thebe](https://github.com/executablebooks/thebe) will use `thebe-core` to provide a `jquery` based connector, that uses prosemirror to enable editing and execution of code cells on any webpage.
 
 `thebe-core` supports connecting to a BinderHub, JupyterHub, any Jupyter instance or JupyterLite with the pyiolite kernel.
 

--- a/packages/lite/CHANGELOG.md
+++ b/packages/lite/CHANGELOG.md
@@ -44,7 +44,7 @@
 
 ### Patch Changes
 
-- Updated interface to allow jupyterlite options to be passed into bundle. React provider updated to access useJuptyerLite prop and react-demo updated to use the new prop.
+- Updated interface to allow jupyterlite options to be passed into bundle. React provider updated to access useJupyterLite prop and react-demo updated to use the new prop.
 
 ## 0.2.0
 
@@ -54,4 +54,4 @@
 
 ### Patch Changes
 
-- Update to juptyerlite 0.1.0
+- Update to jupyterlite 0.1.0

--- a/packages/lite/README.md
+++ b/packages/lite/README.md
@@ -1,6 +1,6 @@
 # `thebe-lite`
 
-Connect to a `pyodide` kernel via `juptyerlite` in `thebe-core` & `thebe`.
+Connect to a `pyodide` kernel via `jupyterlite` in `thebe-core` & `thebe`.
 
 ## Usage
 

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -19,7 +19,7 @@
 
 ### Patch Changes
 
-- 08e008e: Move error handler for the server out of hook and up into the ThebeServerProvider allowing for consistent reactions to an error state accross page navigation.
+- 08e008e: Move error handler for the server out of hook and up into the ThebeServerProvider allowing for consistent reactions to an error state across page navigation.
 - 57dcdaf: ThebeServerProvider will no longer replace an existing server on rerender if that server is ready and has user server URL.
 - 57dcdaf: Hooks no longer throw but return empty or uninitialised objects instead, this allows for much more flexibility in how respective providers are rendered.
 - Updated dependencies [87395cb]
@@ -121,7 +121,7 @@
 
 ### Patch Changes
 
-- Updated interface to allow jupyterlite options to be passed into bundle. React provider updated to access useJuptyerLite prop and react-demo updated to use the new prop.
+- Updated interface to allow jupyterlite options to be passed into bundle. React provider updated to access useJupyterLite prop and react-demo updated to use the new prop.
   - thebe-core@0.2.1
 
 ## 0.2.0

--- a/packages/thebe/e2e/init.spec.ts
+++ b/packages/thebe/e2e/init.spec.ts
@@ -10,7 +10,7 @@ describe('Initialization check', () => {
   test('should have the title "readonly1"', async () => {
     await expect(page.title()).resolves.toMatch('readonly1');
   });
-  test('should have CodeMirror initalized', async () => {
+  test('should have CodeMirror initialized', async () => {
     const text = await page.evaluate(() => document.body.innerHTML);
     expect(text).toContain('thebe-cell');
   });


### PR DESCRIPTION
I ran a spellchecker over some of the docs and fixed the obvious typos.

There's some inconsistency in capitalisation around Jupyter/jupyter etc, and some variations in en-us vs en-gb spellings, but I'm not sure what style you prefer or whether you're keen to enforce it. Plus that sort of copy-editing can take forever!;-)