### PR TITLE
🐿 ship sources for sourcemaps

### DIFF
--- a/.changeset/small-glasses-fold.md
+++ b/.changeset/small-glasses-fold.md
@@ -1,0 +1,8 @@
+---
+'thebe-react': patch
+'thebe': patch
+'thebe-core': patch
+'thebe-lite': patch
+---
+
+Packages now ship their source to enable sourcemaps in development workflows

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -7,7 +7,8 @@
   "types": "dist/types/index.d.ts",
   "style": "dist/lib/thebe-core.css",
   "files": [
-    "dist/**/*"
+    "dist/**/*",
+    "src/**/*"
   ],
   "scripts": {
     "clean": "rm -rf dist",

--- a/packages/lite/package.json
+++ b/packages/lite/package.json
@@ -5,7 +5,8 @@
   "main": "dist/lib/thebe-lite.min.js",
   "types": "dist/types/index.d.ts",
   "files": [
-    "dist/**/*"
+    "dist/**/*",
+    "src/**/*"
   ],
   "scripts": {
     "clean": "rm -rf ./dist",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -6,7 +6,8 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [
-    "dist/**/*"
+    "dist/**/*",
+    "src/**/*"
   ],
   "keywords": [
     "executablebooks",

--- a/packages/thebe/package.json
+++ b/packages/thebe/package.json
@@ -36,7 +36,8 @@
     "publish": "npm publish --tag rc"
   },
   "files": [
-    "lib/**"
+    "lib/**",
+    "src/**/*"
   ],
   "repository": {
     "type": "git",


### PR DESCRIPTION
...currently consumers see missing file errors in their development environments.