### PR TITLE
🎚enable clean shutdown

### DIFF
--- a/packages/react/src/ThebeServerProvider.tsx
+++ b/packages/react/src/ThebeServerProvider.tsx
@@ -142,6 +142,8 @@ export function ThebeServerProvider({
           }
           setReady(false);
           setDoConnect(false);
+          setConnecting(false);
+          setError(undefined);
         },
         error,
       }}


### PR DESCRIPTION
This will clear out provider state and errors when disconnecting and shutting down sessions