### PR TITLE
🕰 await session manager and move exception

### DIFF
--- a/packages/core/src/server.ts
+++ b/packages/core/src/server.ts
@@ -111,9 +111,11 @@ class ThebeServer implements ServerRuntime, ServerRestAPI {
   ): Promise<ThebeSession | null> {
     await this.ready;
 
-    if (!this.sessionManager?.isReady) {
+    if (!this.sessionManager) {
       throw Error('Requesting session from a server, with no SessionManager available');
     }
+
+    await this.sessionManager.ready;
 
     // name is assumed to be a non empty string but is otherwise note required
     // if a notebook name has been supplied on the path, use that otherwise use a default
@@ -157,12 +159,13 @@ class ThebeServer implements ServerRuntime, ServerRestAPI {
 
   async connectToExistingSession(model: SessionIModel, rendermime: IRenderMimeRegistry) {
     await this.ready;
-    if (!this.sessionManager?.isReady) {
+    if (!this.sessionManager) {
       throw Error('Requesting session from a server, with no SessionManager available');
     }
 
-    const connection = this.sessionManager?.connectTo({ model });
+    await this.sessionManager.ready;
 
+    const connection = this.sessionManager?.connectTo({ model });
     return new ThebeSession(this, connection, rendermime);
   }
 

--- a/packages/react/src/hooks/notebook.ts
+++ b/packages/react/src/hooks/notebook.ts
@@ -50,6 +50,7 @@ export function useNotebookBase() {
 
   const executeAll = (options?: NotebookExecuteOptions) => {
     if (!notebook) throw new Error('executeAll called before notebook available');
+    if (!session) throw new Error('executeAll called before session available');
     options?.before?.();
     setExecuting(true);
     return notebook
@@ -69,6 +70,7 @@ export function useNotebookBase() {
     options?: NotebookExecuteOptions,
   ) => {
     if (!notebook) throw new Error('executeSome called before notebook available');
+    if (!session) throw new Error('executeAll called before session available');
     options?.before?.();
     setExecuting(true);
     const filteredCells = notebook.cells.filter(predicate).map((c) => c.id);


### PR DESCRIPTION
unhandled exceptions could occur because of session manager not being ready when we should await it