### PR TITLE
🧹 using origin and pathname only for key

### DIFF
--- a/.changeset/pink-seahorses-smell.md
+++ b/.changeset/pink-seahorses-smell.md
@@ -1,0 +1,5 @@
+---
+'thebe-core': patch
+---
+
+Storage key prefixes for saved sessions are based on url origin and pathname only, hash and query params are ignored

--- a/packages/core/src/sessions.ts
+++ b/packages/core/src/sessions.ts
@@ -2,7 +2,9 @@ import { KernelAPI, ServerConnection } from '@jupyterlab/services';
 import type { SavedSessionInfo, SavedSessionOptions, ServerSettings } from './types';
 
 export function makeStorageKey(storagePrefix: string, url: string) {
-  return storagePrefix + url;
+  const urlObj = new URL(url);
+  // ignore the query string and hash
+  return `${storagePrefix}-${urlObj.origin + urlObj.pathname}`;
 }
 
 export function removeServerInfo(savedSession: Required<SavedSessionOptions>, url: string) {
@@ -94,7 +96,7 @@ export async function getExistingServer(
  *
  * @param storagePrefix
  */
-export function clearAllSavedSessions(storagePrefix: string = 'thebe-binder') {
+export function clearAllSavedSessions(storagePrefix = 'thebe-binder') {
   const keysToRemove: string[] = [];
   for (let i = 0; i < window.localStorage.length; i++) {
     const key = window.localStorage.key(i);
@@ -117,7 +119,7 @@ export function clearAllSavedSessions(storagePrefix: string = 'thebe-binder') {
  * @param storagePrefix
  * @param url
  */
-export function clearSavedSession(storagePrefix: string = 'thebe-binder', url: string = '') {
+export function clearSavedSession(storagePrefix = 'thebe-binder', url = '') {
   console.debug(`thebe:clearSavedSession - removing ${makeStorageKey(storagePrefix, url)}`);
   window.localStorage.removeItem(makeStorageKey(storagePrefix, url));
 }

--- a/packages/core/tests/sessions.spec.ts
+++ b/packages/core/tests/sessions.spec.ts
@@ -1,0 +1,25 @@
+import { describe, test, expect } from 'vitest';
+import { makeStorageKey } from '../src/sessions';
+
+describe('session saving', () => {
+  describe('make storage key', () => {
+    test.each([
+      [
+        'https://mybinder.org/v2/gh/nteract/thebe/master',
+        'prefix-https://mybinder.org/v2/gh/nteract/thebe/master',
+      ],
+      [
+        'https://mybinder.org/v2/gh/nteract/thebe/master#ignored',
+        'prefix-https://mybinder.org/v2/gh/nteract/thebe/master',
+      ],
+      [
+        'https://mybinder.org/v2/gh/nteract/thebe/master?ignored=1&a=42',
+        'prefix-https://mybinder.org/v2/gh/nteract/thebe/master',
+      ],
+      ['https://mybinder.org/', 'prefix-https://mybinder.org/'],
+      ['https://mybinder.org:1234/', 'prefix-https://mybinder.org:1234/'],
+    ])('%s', (url, result) => {
+      expect(makeStorageKey('prefix', url)).toEqual(result);
+    });
+  });
+});


### PR DESCRIPTION
This solves an issue where because of additional query params that vary independent of the session e.g. signed urls or auth tokens, the saved session would not be found and a new server would be started.