### PR TITLE
Inconsistent capitalization: mountRestartallButton

### DIFF
--- a/apps/docs/ui.rst
+++ b/apps/docs/ui.rst
@@ -18,7 +18,7 @@ Cell Buttons
 
 When Thebe is activated, all `<pre>data-executable="true"</pre>` will be converted to code cells and control buttons are rendered by default.
 The buttons are optional, to remove a button, set its respective option to :code:`false`.
-The options are :code:`mountRunButton`, :code:`mountRestartButton`, :code:`mountRestartallButton`.
+The options are :code:`mountRunButton`, :code:`mountRunAllButton`, :code:`mountRestartButton`, :code:`mountRestartAllButton`.
 
 Keyboard Shortcuts
 ==================

--- a/packages/thebe/src/options.ts
+++ b/packages/thebe/src/options.ts
@@ -20,7 +20,7 @@ export interface ThebeOptions {
   mountRunButton?: boolean;
   mountRunAllButton?: boolean;
   mountRestartButton?: boolean;
-  mountRestartallButton?: boolean;
+  mountRestartAllButton?: boolean;
   preRenderHook?: (() => void) | null;
   // thebe specific options
   stripPrompts?: {
@@ -59,7 +59,7 @@ export const defaultOptions: ThebeOptions = {
   mountRunButton: true,
   mountRunAllButton: true,
   mountRestartButton: true,
-  mountRestartallButton: true,
+  mountRestartAllButton: true,
   codeMirrorConfig: {},
 };
 

--- a/packages/thebe/src/render.ts
+++ b/packages/thebe/src/render.ts
@@ -125,7 +125,7 @@ function buildCellUI(
     });
   }
 
-  if (options.mountRestartallButton) {
+  if (options.mountRestartAllButton) {
     restartAll = buildButton(
       controls,
       'restartall',


### PR DESCRIPTION
mountRunAllButton has uppercase All, make consistent.