### PR TITLE
remediate wcag 2.1.2 - no keyboard trap

### DIFF
--- a/packages/thebe/src/codemirror.ts
+++ b/packages/thebe/src/codemirror.ts
@@ -32,6 +32,7 @@ interface RequiredCodeMirrorConfig {
   extraKeys: {
     'Shift-Enter': () => void;
     'Ctrl-Space': () => void;
+    'Esc': () => void;
   };
 }
 
@@ -61,6 +62,10 @@ export function setupCodemirror(
   }
 
   const ref: { cm?: any } = { cm: undefined };
+
+  function unFocus() {
+    ref.cm?.display.input.blur()
+  }
 
   function codeCompletion() {
     console.debug(`thebe:codemirror:codeCompletion`);
@@ -116,7 +121,8 @@ export function setupCodemirror(
     extraKeys: {
       'Shift-Enter': execute,
       'Ctrl-Space': codeCompletion,
-    },
+      'Esc': unFocus,
+  },
   };
 
   const codeMirrorConfig = Object.assign(


### PR DESCRIPTION
hey y'all, i figured i'd kick off this discussion with a pull request instead of an issue. i'm proposing to add support for the <kbd>Esc</kbd>. currently, thebe violates  [Success Criterion 2.1.2 (No Keyboard Trap)](https://www.w3.org/TR/2008/REC-WCAG20-20081211/#keyboard-operation-trapping). this pull request applies technique [G21: Ensuring that users are not trapped in content](https://www.w3.org/WAI/GL/2010/WD-WCAG20-TECHS-20100708/G21) so that when `Esc` is pressed we use `cm.display.input.blur()` to remove focus from the editor allowing keyboard users to continue through their natural tab order.

i'm not really great at js development or testing so i'd appreciate any pointers to cleaning up the pr.