### PR TITLE
🍽️ lite doesn't respect paths

### DIFF
--- a/.changeset/purple-queens-breathe.md
+++ b/.changeset/purple-queens-breathe.md
@@ -1,0 +1,5 @@
+---
+'thebe-core': patch
+---
+
+Notebooks in subfolders will not have relative paths honoured in `thebe-lite`

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ junit.xml
 
 .turbo
 .ipynb_checkpoints
+.yalc/


### PR DESCRIPTION
This fixes: https://github.com/executablebooks/myst-theme/issues/394 in the short term, this fix as valid as there is no filesystem support enabled in `thebe-lite` yet.