### PR TITLE
[doc] Update executablebooks to jupyter-book github org

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,31 +5,31 @@
 ### Deprecations
 
 - `thebe` has been added as an alias for `thebelab` and all css classes beginning with `thebelab-` duplicated as `thebe-`. The `thebelab` global object, exposed functions and user code reliant on css classes `thebelab-*`, will continue to work and any DOM elements created during operation will be decorated with `thebelab-` classes as expected, until removed in version 0.9.0.
-  [#230](https://github.com/executablebooks/thebe/issues/230)
+  [#230](https://github.com/jupyter-book/thebe/issues/230)
 
 ## 0.8.2 - 2021-10-26
 
 ### Fixed
 
 - Fixed broken distribution on `npm`/`unpkg.com` for last release.
-  [#509](https://github.com/executablebooks/thebe/issues/509)
+  [#509](https://github.com/jupyter-book/thebe/issues/509)
 
 ## 0.8.1 - 2021-10-25
 
 ### Fixed
 
 - Fixed import of jupyterlab css which was clobbering on page css in downstream usage.
-  [#464](https://github.com/executablebooks/thebe/issues/464)
+  [#464](https://github.com/jupyter-book/thebe/issues/464)
 
 ### Added
 
 - Added a built in status indicator and activate button that can be enabled via configuration options.
-  [#470](https://github.com/executablebooks/thebe/issues/470)
+  [#470](https://github.com/jupyter-book/thebe/issues/470)
 
 ### Improved
 
 - Latest version of Thebe is built and used in the documentation and in local development builds.
-  [#285](https://github.com/executablebooks/thebe/issues/285)
+  [#285](https://github.com/jupyter-book/thebe/issues/285)
 - Improved and updated examples in the documentation
 - `yarn install` no longer builds the library automatically, `yarn build` or `yarn build:prod` should be called explicitly.
 
@@ -38,32 +38,32 @@
 ### Added
 
 - Added a busy indicator to provide feedback about computation.
-  [#424](https://github.com/executablebooks/thebe/pull/424)
+  [#424](https://github.com/jupyter-book/thebe/pull/424)
 - Added convenience commands for testing with local kernels.
-  [#425](https://github.com/executablebooks/thebe/pull/425)
+  [#425](https://github.com/jupyter-book/thebe/pull/425)
 
 ### Documented
 
 - Added a pythreejs example.
-  [#262](https://github.com/executablebooks/thebe/pull/262)
+  [#262](https://github.com/jupyter-book/thebe/pull/262)
 - Added an ipywidgets example.
-  [#418](https://github.com/executablebooks/thebe/pull/418)
+  [#418](https://github.com/jupyter-book/thebe/pull/418)
 
 ### Improved
 
 - Switched to the jupyterlab manager to control output display, fixes issues
-  with ipywidgets. [#418](https://github.com/executablebooks/thebe/pull/418)
+  with ipywidgets. [#418](https://github.com/jupyter-book/thebe/pull/418)
 - Switched package managers from npm to yarn.
-  [#428](https://github.com/executablebooks/thebe/pull/428)
+  [#428](https://github.com/jupyter-book/thebe/pull/428)
 
 ## 0.7.1 - 2021-04-09
 
 ### Fixed
 
 - Pressing "Restart and Run All" now starts a kernel if none has been started
-  already. [#345](https://github.com/executablebooks/thebe/pull/345)
+  already. [#345](https://github.com/jupyter-book/thebe/pull/345)
 - Fixed kernel communication connection in ThebeManager.
-  [#330](https://github.com/executablebooks/thebe/pull/330)
+  [#330](https://github.com/jupyter-book/thebe/pull/330)
 
 ## 0.6.0 - 2020-12-23
 
@@ -72,50 +72,50 @@
 - New versions of thebe (>=0.5.1) should be loaded from
   https://unpkg.com/thebe@latest/lib/index.js instead of
   https://unpkg.com/thebelab@latest/lib/index.js
-- End to end integration tests using Jest [#282](https://github.com/executablebooks/thebe/pull/282), [#297](https://github.com/executablebooks/thebe/pull/297)
-- Read-only option for code blocks [#274](https://github.com/executablebooks/thebe/pull/274)
-- Persistence of Binder sessions across pages [#266](https://github.com/executablebooks/thebe/pull/266)
-- Restart and run all buttons [#270](https://github.com/executablebooks/thebe/pull/270)
-- Show an error message when the kernel is dead [#279](https://github.com/executablebooks/thebe/pull/279)
-- GitHub workflows to publish on NPM [#236](https://github.com/executablebooks/thebe/pull/236)
-- Load CodeMirror Themes [#194](https://github.com/executablebooks/thebe/pull/194)
-- Add development page for testing [#193](https://github.com/executablebooks/thebe/pull/193)
-- Add CSS with Jupyter ANSI colors [#176](https://github.com/executablebooks/thebe/pull/176)
+- End to end integration tests using Jest [#282](https://github.com/jupyter-book/thebe/pull/282), [#297](https://github.com/jupyter-book/thebe/pull/297)
+- Read-only option for code blocks [#274](https://github.com/jupyter-book/thebe/pull/274)
+- Persistence of Binder sessions across pages [#266](https://github.com/jupyter-book/thebe/pull/266)
+- Restart and run all buttons [#270](https://github.com/jupyter-book/thebe/pull/270)
+- Show an error message when the kernel is dead [#279](https://github.com/jupyter-book/thebe/pull/279)
+- GitHub workflows to publish on NPM [#236](https://github.com/jupyter-book/thebe/pull/236)
+- Load CodeMirror Themes [#194](https://github.com/jupyter-book/thebe/pull/194)
+- Add development page for testing [#193](https://github.com/jupyter-book/thebe/pull/193)
+- Add CSS with Jupyter ANSI colors [#176](https://github.com/jupyter-book/thebe/pull/176)
 
 ### Improved
 
-- Adds more user options for persisting saved Binder sessions [#280](https://github.com/executablebooks/thebe/pull/280)
-- Updated the development HTML page for more test code cells and configs [#267](https://github.com/executablebooks/thebe/pull/267)
-- Fail linter on diffs [#258](https://github.com/executablebooks/thebe/pull/258)
-- Restores full jQuery to ensure compatiblity with jQuery UI [#189](https://github.com/executablebooks/thebe/pull/189)
-- Changes to test layout (when Thebe was still using Karma, as of writing, Thebe now uses Jest) [#257](https://github.com/executablebooks/thebe/pull/257)
-- Update Thebe to use the latest JupyterLab 3.0 APIs [#268](https://github.com/executablebooks/thebe/pull/268)
+- Adds more user options for persisting saved Binder sessions [#280](https://github.com/jupyter-book/thebe/pull/280)
+- Updated the development HTML page for more test code cells and configs [#267](https://github.com/jupyter-book/thebe/pull/267)
+- Fail linter on diffs [#258](https://github.com/jupyter-book/thebe/pull/258)
+- Restores full jQuery to ensure compatiblity with jQuery UI [#189](https://github.com/jupyter-book/thebe/pull/189)
+- Changes to test layout (when Thebe was still using Karma, as of writing, Thebe now uses Jest) [#257](https://github.com/jupyter-book/thebe/pull/257)
+- Update Thebe to use the latest JupyterLab 3.0 APIs [#268](https://github.com/jupyter-book/thebe/pull/268)
 
 ### Fixed
 
-- Fix Python mode in CodeMirror configuration [#172](https://github.com/executablebooks/thebe/pull/172)
-- Use merged options in CodeMirror configuration [#171](https://github.com/executablebooks/thebe/pull/171)
+- Fix Python mode in CodeMirror configuration [#172](https://github.com/jupyter-book/thebe/pull/172)
+- Use merged options in CodeMirror configuration [#171](https://github.com/jupyter-book/thebe/pull/171)
 
 ### Documented
 
-- Moved example pages into their own subdirectory [#281](https://github.com/executablebooks/thebe/pull/281)
+- Moved example pages into their own subdirectory [#281](https://github.com/jupyter-book/thebe/pull/281)
 - Added example pages for using Thebe with other Jupyter widgets
-  - Bqplot [#295](https://github.com/executablebooks/thebe/pull/295), [#301](https://github.com/executablebooks/thebe/pull/301)
-  - Ipycytoscape [#283](https://github.com/executablebooks/thebe/pull/283)
-  - Plotly [#269](https://github.com/executablebooks/thebe/pull/269)
-  - Ipyleaflet [#265](https://github.com/executablebooks/thebe/pull/265)
-  - ipympl [#294](https://github.com/executablebooks/thebe/pull/294)
-- Documented read-only code-blocks [#287](https://github.com/executablebooks/thebe/pull/287), [#286](https://github.com/executablebooks/thebe/pull/286)
-- Updated repository links and other references due to migrating the repository to [executablebooks](https://github.com/executablebooks) [#275](https://github.com/executablebooks/thebe/pull/275), [#273](https://github.com/executablebooks/thebe/pull/273), [#232](https://github.com/executablebooks/thebe/pull/232)
+  - Bqplot [#295](https://github.com/jupyter-book/thebe/pull/295), [#301](https://github.com/jupyter-book/thebe/pull/301)
+  - Ipycytoscape [#283](https://github.com/jupyter-book/thebe/pull/283)
+  - Plotly [#269](https://github.com/jupyter-book/thebe/pull/269)
+  - Ipyleaflet [#265](https://github.com/jupyter-book/thebe/pull/265)
+  - ipympl [#294](https://github.com/jupyter-book/thebe/pull/294)
+- Documented read-only code-blocks [#287](https://github.com/jupyter-book/thebe/pull/287), [#286](https://github.com/jupyter-book/thebe/pull/286)
+- Updated repository links and other references due to migrating the repository to [executablebooks](https://github.com/executablebooks) [#275](https://github.com/jupyter-book/thebe/pull/275), [#273](https://github.com/jupyter-book/thebe/pull/273), [#232](https://github.com/jupyter-book/thebe/pull/232)
 - Contribution information
-  - Instructions on how to build the docs [#260](https://github.com/executablebooks/thebe/pull/260)
-  - Commits, architecture, etc. [#248](https://github.com/executablebooks/thebe/pull/248)
-  - Releases [#236](https://github.com/executablebooks/thebe/pull/236)
-  - Contributing guide [#232](https://github.com/executablebooks/thebe/pull/232)
-- Event hooks [#222](https://github.com/executablebooks/thebe/pull/222)
-- Security concerns on XXS (Cross-Site Scripting) [#263](https://github.com/executablebooks/thebe/pull/264)
-- Use JSDoc to build JS API docs [#248](https://github.com/executablebooks/thebe/pull/248)
-- Configuration information, getting started, CircleCI jobs, Sphinx book theme [#218](https://github.com/executablebooks/thebe/pull/218)
-- Clarify kernelName in README [#180](https://github.com/executablebooks/thebe/pull/180)
-- CodeMirror configuration page [#174](https://github.com/executablebooks/thebe/pull/174/files)
-- Use the latest Thebe version [#173](https://github.com/executablebooks/thebe/pull/173)
+  - Instructions on how to build the docs [#260](https://github.com/jupyter-book/thebe/pull/260)
+  - Commits, architecture, etc. [#248](https://github.com/jupyter-book/thebe/pull/248)
+  - Releases [#236](https://github.com/jupyter-book/thebe/pull/236)
+  - Contributing guide [#232](https://github.com/jupyter-book/thebe/pull/232)
+- Event hooks [#222](https://github.com/jupyter-book/thebe/pull/222)
+- Security concerns on XXS (Cross-Site Scripting) [#263](https://github.com/jupyter-book/thebe/pull/264)
+- Use JSDoc to build JS API docs [#248](https://github.com/jupyter-book/thebe/pull/248)
+- Configuration information, getting started, CircleCI jobs, Sphinx book theme [#218](https://github.com/jupyter-book/thebe/pull/218)
+- Clarify kernelName in README [#180](https://github.com/jupyter-book/thebe/pull/180)
+- CodeMirror configuration page [#174](https://github.com/jupyter-book/thebe/pull/174/files)
+- Use the latest Thebe version [#173](https://github.com/jupyter-book/thebe/pull/173)

--- a/README_0.8.x.md
+++ b/README_0.8.x.md
@@ -1,6 +1,6 @@
 # Thebe: turn static HTML pages into live documents
 
-![test](https://github.com/executablebooks/thebe/workflows/test/badge.svg)
+![test](https://github.com/jupyter-book/thebe/workflows/test/badge.svg)
 [![Documentation Status](https://readthedocs.org/projects/thebe/badge/?version=latest)](https://thebe.readthedocs.io/en/latest/?badge=latest)
 
 Have a static HTML page with code snippets? Your readers can edit and execute them right there. All it takes is:

--- a/apps/demo-core/CHANGELOG.md
+++ b/apps/demo-core/CHANGELOG.md
@@ -61,7 +61,7 @@
 
 ### Patch Changes
 
-- 7279d5b: fixed interact based ipywidgets and ipympl functionality, now aligning with behaviour seen in voila and jputyerlab. See [issue 608](https://github.com/executablebooks/thebe/issues/608)
+- 7279d5b: fixed interact based ipywidgets and ipympl functionality, now aligning with behaviour seen in voila and jputyerlab. See [issue 608](https://github.com/jupyter-book/thebe/issues/608)
 - Updated dependencies [7279d5b]
   - thebe-core@0.1.4
 

--- a/apps/demo-core/package.json
+++ b/apps/demo-core/package.json
@@ -22,10 +22,10 @@
   "private": true,
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/executablebooks/thebe-core.git"
+    "url": "git+https://github.com/jupyter-book/thebe-core.git"
   },
   "bugs": {
-    "url": "https://github.com/executablebooks/thebe-core/issues"
+    "url": "https://github.com/jupyter-book/thebe-core/issues"
   },
   "author": "Steve Purves",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/executablebooks/thebe.git"
+    "url": "git+https://github.com/jupyter-book/thebe.git"
   },
   "keywords": [
     "jupyter",
@@ -45,7 +45,7 @@
   "author": "Executable Books Project",
   "license": "BSD-3-Clause",
   "bugs": {
-    "url": "https://github.com/executablebooks/thebe/issues"
+    "url": "https://github.com/jupyter-book/thebe/issues"
   },
   "engines": {
     "npm": ">= 6.0",

--- a/packages/build-config/CHANGELOG.md
+++ b/packages/build-config/CHANGELOG.md
@@ -10,4 +10,4 @@
 
 ### Patch Changes
 
-- 7279d5b: fixed interact based ipywidgets and ipympl functionality, now aligning with behaviour seen in voila and jputyerlab. See [issue 608](https://github.com/executablebooks/thebe/issues/608)
+- 7279d5b: fixed interact based ipywidgets and ipympl functionality, now aligning with behaviour seen in voila and jputyerlab. See [issue 608](https://github.com/jupyter-book/thebe/issues/608)

--- a/packages/build-config/package.json
+++ b/packages/build-config/package.json
@@ -6,7 +6,7 @@
   "scripts": {},
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/executablebooks/thebe.git"
+    "url": "git+https://github.com/jupyter-book/thebe.git"
   },
   "keywords": [
     "thebe",
@@ -15,9 +15,9 @@
   "author": "Steve Purves <stevejpurves@gmail.com>",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/executablebooks/thebe/issues"
+    "url": "https://github.com/jupyter-book/thebe/issues"
   },
-  "homepage": "https://github.com/executablebooks/thebe#readme",
+  "homepage": "https://github.com/jupyter-book/thebe#readme",
   "devDependencies": {
     "jest-junit": "^16.0.0",
     "webpack": "^5.74.0"

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -245,7 +245,7 @@
 
 ### Patch Changes
 
-- 7279d5b: fixed interact based ipywidgets and ipympl functionality, now aligning with behaviour seen in voila and jputyerlab. See [issue 608](https://github.com/executablebooks/thebe/issues/608)
+- 7279d5b: fixed interact based ipywidgets and ipympl functionality, now aligning with behaviour seen in voila and jputyerlab. See [issue 608](https://github.com/jupyter-book/thebe/issues/608)
 
 ## 0.1.3
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -2,7 +2,7 @@
 
 `thebe-core` is a headless connector library allowing a developer to connect to and execute code on a Jupyter based compute resource from any Javascript environemnt.
 
-Written in Typescript and indended for use in other packages and applications, `thebe-core` has minimal state and introduces no restrictions on UI frameworks that might be used. [thebe](https://github.com/executablebooks/thebe) will use `thebe-core` to provide a `jquery` based connector, that uses prosemirror to enable editing and execution of code cells on any webpage.
+Written in Typescript and indended for use in other packages and applications, `thebe-core` has minimal state and introduces no restrictions on UI frameworks that might be used. [thebe](https://github.com/jupyter-book/thebe) will use `thebe-core` to provide a `jquery` based connector, that uses prosemirror to enable editing and execution of code cells on any webpage.
 
 `thebe-core` supports connecting to a BinderHub, JupyterHub, any Jupyter instance or JupyterLite with the pyiolite kernel.
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -44,10 +44,10 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/executablebooks/thebe.git"
+    "url": "git+https://github.com/jupyter-book/thebe.git"
   },
   "bugs": {
-    "url": "https://github.com/executablebooks/thebe/issues"
+    "url": "https://github.com/jupyter-book/thebe/issues"
   },
   "author": {
     "name": "Steve Purves",

--- a/packages/core/tests/url.spec.ts
+++ b/packages/core/tests/url.spec.ts
@@ -113,7 +113,7 @@ describe('building binder urls', () => {
           WELL_KNOWN_REPO_PROVIDERS,
         ),
       ).toEqual({
-        build: 'https://binder.curvenote.dev/build/gist/executablebooks/thebe-binder-base/main',
+        build: 'https://binder.curvenote.dev/build/gist/jupyter-book/thebe-binder-base/main',
         launch: 'https://binder.curvenote.dev/v2/gist/executablebooks/thebe-binder-base/main',
         storageKey:
           'thebe-binder-https://binder.curvenote.dev/build/gist/executablebooks/thebe-binder-base/main',

--- a/packages/lite/package.json
+++ b/packages/lite/package.json
@@ -20,7 +20,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/executablebooks/thebe.git"
+    "url": "git+https://github.com/jupyter-book/thebe.git"
   },
   "keywords": [
     "executablebooks",
@@ -41,9 +41,9 @@
   },
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/executablebooks/thebe/issues"
+    "url": "https://github.com/jupyter-book/thebe/issues"
   },
-  "homepage": "https://github.com/executablebooks/thebe#readme",
+  "homepage": "https://github.com/jupyter-book/thebe#readme",
   "dependencies": {
     "@jupyterlab/coreutils": "^6.2.5",
     "@jupyterlite/pyodide-kernel": "0.4.7",

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -267,7 +267,7 @@
 
 ### Patch Changes
 
-- 7279d5b: fixed interact based ipywidgets and ipympl functionality, now aligning with behaviour seen in voila and jputyerlab. See [issue 608](https://github.com/executablebooks/thebe/issues/608)
+- 7279d5b: fixed interact based ipywidgets and ipympl functionality, now aligning with behaviour seen in voila and jputyerlab. See [issue 608](https://github.com/jupyter-book/thebe/issues/608)
 - Updated dependencies [7279d5b]
   - thebe-core@0.1.4
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -22,10 +22,10 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/executablebooks/thebe.git"
+    "url": "git+https://github.com/jupyter-book/thebe.git"
   },
   "bugs": {
-    "url": "https://github.com/executablebooks/thebe/issues"
+    "url": "https://github.com/jupyter-book/thebe/issues"
   },
   "scripts": {
     "clean": "rm -rf dist",

--- a/packages/thebe/CHANGELOG.md
+++ b/packages/thebe/CHANGELOG.md
@@ -90,12 +90,12 @@
 
 ### Patch Changes
 
-- 7279d5b: fixed interact based ipywidgets and ipympl functionality, now aligning with behaviour seen in voila and jputyerlab. See [issue 608](https://github.com/executablebooks/thebe/issues/608)
+- 7279d5b: fixed interact based ipywidgets and ipympl functionality, now aligning with behaviour seen in voila and jputyerlab. See [issue 608](https://github.com/jupyter-book/thebe/issues/608)
 - Updated dependencies [7279d5b]
 
   - thebe-core@0.1.4
 
-- bfe8ede: fall back to `kernelName` when `name` not specified (issue 595)[https://github.com/executablebooks/thebe/issues/595]
+- bfe8ede: fall back to `kernelName` when `name` not specified (issue 595)[https://github.com/jupyter-book/thebe/issues/595]
 
 ## 0.9.0-rc.3
 

--- a/packages/thebe/package.json
+++ b/packages/thebe/package.json
@@ -44,7 +44,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/executablebooks/thebe.git"
+    "url": "git+https://github.com/jupyter-book/thebe.git"
   },
   "keywords": [
     "jupyter",
@@ -53,7 +53,7 @@
   "author": "Executable Books Project",
   "license": "BSD-3-Clause",
   "bugs": {
-    "url": "https://github.com/executablebooks/thebe/issues"
+    "url": "https://github.com/jupyter-book/thebe/issues"
   },
   "engines": {
     "npm": ">= 6.0",


### PR DESCRIPTION
This updates a few links to point to `jupyter-book` instead of `executablebooks/`. I tried not to touch anything in the tests, since this is more for public docs / branding and I didn't want to chance breaking anything. I think that's fine.

I'll plan to merge this in a day or two if nobody objects!